### PR TITLE
Python 3.5 対応

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -10,13 +10,14 @@ from pathlib import Path
 from subprocess import (DEVNULL, PIPE, STDOUT, CalledProcessError,
                         TimeoutExpired, call, check_call, check_output, run)
 from tempfile import TemporaryDirectory
+from typing import Any, List, MutableMapping, Union
 
 import toml
 
 logger = getLogger(__name__)  # type: Logger
 
 
-def casename(name: str, i: int) -> str:
+def casename(name: Union[str, Path], i: int) -> str:
     # (random, 1) -> random_01
     return Path(name).stem + '_' + str(i).zfill(2)
 
@@ -43,7 +44,7 @@ def compile(src: Path, libdir: Path):
         raise UnknownTypeFile('Unknown file: {}'.format(src))
 
 
-def execcmd(src: Path, arg: [str] = []) -> [str]:
+def execcmd(src: Path, arg: List[str] = []) -> List[str]:
     # main.cpp -> ['main']
     # example.in -> ['cat', 'example_00.in']
     if src.suffix == '.cpp':
@@ -59,12 +60,10 @@ def execcmd(src: Path, arg: [str] = []) -> [str]:
 
 
 class Problem:
-    config = None
-
     def __init__(self, libdir: Path, basedir: Path):
         self.libdir = libdir  # type: Path
         self.basedir = basedir  # type: Path
-        self.config = toml.load(basedir / 'info.toml')
+        self.config = toml.load(basedir / 'info.toml')  # type: MutableMapping[str, Any]
 
     def compile_correct(self):
         logger.info('compile solution')

--- a/generate.py
+++ b/generate.py
@@ -13,7 +13,7 @@ from tempfile import TemporaryDirectory
 
 import toml
 
-logger: Logger = getLogger(__name__)
+logger = getLogger(__name__)  # type: Logger
 
 
 def casename(name: str, i: int) -> str:
@@ -34,8 +34,8 @@ def compile(src: Path, libdir: Path):
         if platform.system() == 'Darwin':
             cxxflags_default += ' -Wl,-stack_size,0x10000000'  # 256MB
         cxxflags = getenv('CXXFLAGS', cxxflags_default).split()
-        cxxflags.extend(['-I', libdir / 'common'])
-        check_call([cxx] + cxxflags + ['-o', src.with_suffix('')] + [src])
+        cxxflags.extend(['-I', str(libdir / 'common')])
+        check_call([cxx] + cxxflags + ['-o', str(src.with_suffix(''))] + [str(src)])
     elif src.suffix == '.in':
         pass
     else:
@@ -47,25 +47,23 @@ def execcmd(src: Path, arg: [str] = []) -> [str]:
     # main.cpp -> ['main']
     # example.in -> ['cat', 'example_00.in']
     if src.suffix == '.cpp':
-        cmd = [src.with_suffix('').resolve()]
+        cmd = [str(src.with_suffix('').resolve())]
         cmd.extend(arg)
         return cmd
     elif src.suffix == '.in':
         inpath = src.with_name(casename(src, int(arg[0])) + '.in')
-        cmd = ['cat', inpath]
+        cmd = ['cat', str(inpath)]
         return cmd
     else:
         raise UnknownTypeFile('Unknown file: {} {}'.format(src, arg))
 
 
 class Problem:
-    libdir: Path()
-    basedir: Path()
     config = None
 
     def __init__(self, libdir: Path, basedir: Path):
-        self.libdir = libdir
-        self.basedir = basedir
+        self.libdir = libdir  # type: Path
+        self.basedir = basedir  # type: Path
         self.config = toml.load(basedir / 'info.toml')
 
     def compile_correct(self):
@@ -98,7 +96,7 @@ class Problem:
 
         logger.info('clear input {}'.format(indir))
         if indir.exists():
-            shutil.rmtree(indir)
+            shutil.rmtree(str(indir))
         indir.mkdir()
 
         for test in self.config['tests']:
@@ -109,7 +107,7 @@ class Problem:
             for i in range(num):
                 inpath = indir / (casename(name, i) + '.in')
                 check_call(
-                    execcmd(gendir / name, [str(i)]), stdout=open(inpath, 'w'))
+                    execcmd(gendir / name, [str(i)]), stdout=open(str(inpath), 'w'))
 
     def verify_inputs(self):
         indir = self.basedir / 'in'
@@ -122,7 +120,7 @@ class Problem:
             for i in range(num):
                 inpath = indir / (casename(name, i) + '.in')
                 check_call(
-                    execcmd(gendir / self.config['verify']), stdin=open(inpath, 'r'))
+                    execcmd(gendir / self.config['verify']), stdin=open(str(inpath), 'r'))
 
     def make_outputs(self):
         indir = self.basedir / 'in'
@@ -131,7 +129,7 @@ class Problem:
 
         logger.info('clear output {}'.format(outdir))
         if outdir.exists():
-            shutil.rmtree(outdir)
+            shutil.rmtree(str(outdir))
         outdir.mkdir()
 
         for test in self.config['tests']:
@@ -143,7 +141,7 @@ class Problem:
                 outpath = outdir / (casename(name, i) + '.out')
                 logger.info('start ' + casename(name, i) + '...')
                 check_call(execcmd(soldir / self.config['solution']),
-                           stdin=open(inpath, 'r'), stdout=open(outpath, 'w'))
+                           stdin=open(str(inpath), 'r'), stdout=open(str(outpath), 'w'))
 
     def judge(self, src: Path, config: dict):
         indir = self.basedir / 'in'
@@ -167,15 +165,15 @@ class Problem:
                 result = ''
                 checker_output = ''
                 try:
-                    check_call(execcmd(src), stdin=open(infile, 'r'), stdout=open(
-                        actual, 'w'), timeout=self.config['timelimit'])
+                    check_call(execcmd(src), stdin=open(str(infile), 'r'), stdout=open(
+                        str(actual), 'w'), timeout=self.config['timelimit'])
                 except TimeoutExpired:
                     result = 'TLE'
                 except CalledProcessError:
                     result = 'RE'
                 else:
                     process = run(
-                        execcmd(checker, [infile, actual, expected]), stdout=PIPE, stderr=STDOUT)
+                        execcmd(checker, [str(infile), str(actual), str(expected)]), stdout=PIPE, stderr=STDOUT)
                     checker_output = process.stdout
                     if process.returncode:
                         result = 'WA'
@@ -202,7 +200,7 @@ class Problem:
         logger.info('generate doc')
         html = ToHTMLConverter(self.basedir)
         path = self.basedir / 'task.html' if not htmldir else htmldir / (self.basedir.name + '.html')
-        with open(path, 'w', encoding='utf-8') as f:
+        with open(str(path), 'w', encoding='utf-8') as f:
             f.write(html.html)
 
 

--- a/htmlgen.py
+++ b/htmlgen.py
@@ -21,7 +21,7 @@ import toml
 from markdown import Extension, markdown
 from markdown.preprocessors import Preprocessor
 
-logger: Logger = getLogger(__name__)
+logger = getLogger(__name__)  # type: Logger
 
 
 class ExampreExpander(Preprocessor):
@@ -45,10 +45,10 @@ class ExampreExpander(Preprocessor):
             if line.startswith(start) and line.endswith(end):
                 name = line[len(start):-len(end)]
 
-                infile = open(self.base_path / 'in' /
-                              (name + '.in'), 'r').read()
-                outfile = open(self.base_path / 'out' /
-                               (name + '.out'), 'r').read()
+                infile = open(str(self.base_path / 'in' /
+                              (name + '.in')), 'r').read()
+                outfile = open(str(self.base_path / 'out' /
+                               (name + '.out')), 'r').read()
 
                 new_lines.append(r'### # {}'.format(counter))
                 new_lines.extend(self.sample_template.format(
@@ -117,16 +117,14 @@ class ToHTMLConverter:
 </body>
 </html>
 '''
-    html: str
-    statement: str
 
     def __init__(self, probdir: Path):
-        with open(probdir / 'task.md', encoding='utf-8') as f:
+        with open(str(probdir / 'task.md'), encoding='utf-8') as f:
             self.statement = markdown(
                 f.read(), extensions=[
                     'markdown.extensions.fenced_code',
                     'markdown.extensions.tables',
                     ExampleExtension(base_path=str(probdir))
                 ],
-            )
-            self.html = self.header + self.body_template.format(self.statement)
+            )  # type: str
+            self.html = self.header + self.body_template.format(self.statement)  # type: str


### PR DESCRIPTION
#127 のやつです。しました。

-   やったのは主に、
    1. 変数への注釈をコメント形式にすることと、
    2. `pathlib.Path` を受けとってくれない部分を `str` に変換することです。
-   ついでに壊れていた型ヒントをいくつか修正しました。
-   検証は手元環境の Python 3.5 (https://askubuntu.com/questions/682869/how-do-i-install-a-different-python-version-using-apt-get/682875#682875 で入れた) でしました。
-   修正量からも分かるように、油断するとすぐにだめになります。CI で Python 3.5 対応を確認した方がよいです (CircleCI は分からないので、やるとしてもこれは @yosupo06 に任せたいです)。