### PR TITLE
add n_131072.cpp for rectangle_sum

### DIFF
--- a/datastructure/rectangle_sum/gen/n_131072.cpp
+++ b/datastructure/rectangle_sum/gen/n_131072.cpp
@@ -1,0 +1,49 @@
+#include "random.h"
+#include <iostream>
+#include <tuple>
+
+using namespace std;
+
+int main(int, char* argv[]) {
+    cin.tie(nullptr);
+    ios::sync_with_stdio(false);
+
+    long long seed = atoll(argv[1]);
+    auto gen = Random(seed);
+
+    int n = 131072;
+    int q = 200000;
+    cout << n << " " << q << "\n";
+    vector<int> ys = gen.perm<int>(n);
+    for (int i = 0; i < n; i++) {
+        int x = 2 * i;
+        int y = 2 * ys[i];
+        int w = gen.uniform(0, 1'000'000'000);
+        cout << x << " " << y << " " << w << "\n";
+    }
+    for (int i = 0; i < q; i++) {
+        int l, d, r, u;
+        tie(l, r) = gen.uniform_pair(0, 2 * n);
+        tie(d, u) = gen.uniform_pair(0, 2 * n);
+        if (gen.uniform_bool()) {
+            l = 0;
+        }
+        if (gen.uniform_bool()) {
+            d = 0;
+        }
+        if (gen.uniform_bool()) {
+            r = 2 * n;
+        }
+        if (gen.uniform_bool()) {
+            u = 2 * n;
+        }
+        if (gen.uniform_bool()) {
+            r = l + 1;
+        }
+        if (gen.uniform_bool()) {
+            u = d + 1;
+        }
+        cout << l << " " << d << " " << r << " " << u << "\n";
+    }
+    return 0;
+}

--- a/datastructure/rectangle_sum/info.toml
+++ b/datastructure/rectangle_sum/info.toml
@@ -16,6 +16,9 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/118"
 [[tests]]
     name = "xy_concentrate.cpp"
     number = 3
+[[tests]]
+    name = "n_131072.cpp"
+    number = 1
 
 [[solutions]]
     name = "naive.cpp"


### PR DESCRIPTION
#118 の追加ケース

多くの実装のsegtreeはNが2冪の時に特殊な操作をする(=バグりやすい)ので

例えば　https://judge.yosupo.jp/submission/2005　が落ちる