### PR TITLE
add cache feature to generate.py

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -206,7 +206,7 @@ class Problem:
         latest_timestamp = min(datetime.fromtimestamp(path.stat().st_mtime) for path in testcases)
 
         # compare the timestamp with other files
-        for path in list(self.basedir.glob('**/*')) + list(self.libdir.glob('**/*')):
+        for path in list(self.basedir.glob('**/*')) + list(self.libdir.glob('common/**/*')):
             if path in testcases:
                 continue
             if not path.is_file():

--- a/generate.py
+++ b/generate.py
@@ -203,9 +203,9 @@ class Problem:
                 testcases.add(infile)
                 testcases.add(expected)
 
-        latest_timestamp = min(datetime.fromtimestamp(path.stat().st_mtime) for path in testcases)
+        latest_timestamp = min(datetime.fromtimestamp(path.stat().st_mtime) for path in testcases)  # Here you should use min, not max. We want ensure that all testcases are newer than all source files.
 
-        # compare the timestamp with other files
+        # compare the timestamp with other files (including header files in common/)
         for path in list(self.basedir.glob('**/*')) + list(self.libdir.glob('common/**/*')):
             if path in testcases:
                 continue

--- a/generate.py
+++ b/generate.py
@@ -206,7 +206,7 @@ class Problem:
         latest_timestamp = min(datetime.fromtimestamp(path.stat().st_mtime) for path in testcases)
 
         # compare the timestamp with other files
-        for path in self.basedir.glob('**/*'):
+        for path in list(self.basedir.glob('**/*')) + list(self.libdir.glob('**/*')):
             if path in testcases:
                 continue
             if not path.is_file():


### PR DESCRIPTION
#8 
https://github.com/kmyk/online-judge-verify-helper でほしいので書きました

仕様など:

-   生成予定のファイル (`in/*.in` `out/*.out`) に抜けがあったりそれらより後に変更があったファイルがあればすべて再生成、そうでなければ生成をスキップする
-   他のオプション `--verify` を付けても動く (実行可能フラグのあるファイルや `.html` は無視する)
-  「verify に失敗したときにファイルを消す」みたいなのはしていない
-   デフォルトで有効 / `--ignore-cache` を付けると無効