### PR TITLE
fix typo in point_set_range_composite/task

### DIFF
--- a/datastructure/point_set_range_composite/task.md
+++ b/datastructure/point_set_range_composite/task.md
@@ -23,7 +23,7 @@ $N$ $Q$
 $a_0$ $b_0$
 $a_1$ $b_1$
 :
-$a{N - 1}$ $b_{N - 1}$
+$a_{N - 1}$ $b_{N - 1}$
 $\textrm{Query}_0$
 $\textrm{Query}_1$
 :


### PR DESCRIPTION
fix typo

![Annotation 2020-01-03 021358](https://user-images.githubusercontent.com/1732074/71681348-bbc5bd00-2dcf-11ea-8055-2d020915bd7a.png)
