### PR TITLE
fix generate.py: remove problems.toml and deprecated --nogen, --sol, --htmldir

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
           command: |
             pip install --user -r requirements.txt
             ulimit -s unlimited
-            ./generate.py problems.toml --verify --sol
+            ./generate.py $(find . -name "info.toml" -not -path "./test/*") --verify
           environment:           
             CXX: clang++
             CXXFLAGS: -O2 -std=c++14 -stdlib=libc++ -Wall -Wextra -Werror
@@ -33,7 +33,7 @@ jobs:
           command: |
             pip install --user -r requirements.txt
             ulimit -s unlimited
-            ./generate.py problems.toml --verify --sol --html --htmldir=/tmp/html
+            ./generate.py $(find . -name "info.toml" -not -path "./test/*") --verify --html --htmldir=/tmp/html
       - store_artifacts:
           path: /tmp/html
 

--- a/README.md
+++ b/README.md
@@ -30,27 +30,21 @@ pip3 install toml markdown
 ulimit -s unlimited # for linux (don't need for os x)
 
 # generate testcase
-./generate.py problems.toml # generate testcases of all problems
-./generate.py problems.toml -p unionfind # generate testcases of unionfind
+./generate.py -p unionfind # generate testcases of unionfind
+# or ./generate.py datastructure/unionfind/info.toml
 ls datastructure/unionfind/in/ # testcases of unionfind
 ls datastructure/unionfind/out/ # solutions of unionfind
 
+./generate.py $(find . -name "info.toml" -not -path "./test/*") # generate testcases of all problems
+
 # generate hash(For developers)
-./generate.py problems.toml --refhash # if you fix some code, you have to regenerate hashes of testcases
+./generate.py -p unionfind --refhash # if you fix some code, you have to regenerate hashes of testcases
 
 # verify
-./generate.py problems.toml --verify # generate testcases & run input checker
-./generate.py problems.toml --nogen --verify # run input checker(without generate testcases, you must generate already)
-./generate.py problems.toml --nogen --verify -p unionfind # of cource, it is ok
-
-# other solutions check
-./generate.py problems.toml --sol # generate testcases & run other solution
-./generate.py problems.toml --nogen --sol
-./generate.py problems.toml --nogen --sol -p unionfind
+./generate.py -p unionfind --verify # generate testcases & run input checker & run other solutions
 
 # generate statement
-./generate.py problems.toml --html # generate testcases & generate html
-./generate.py problems.toml --nogen --html
+./generate.py -p unionfind --html # generate testcases & generate html
 ls datastructure/unionfind/task.html # statement
 ```
 

--- a/ci_generate.py
+++ b/ci_generate.py
@@ -28,4 +28,4 @@ if __name__ == '__main__':
         for n in names:
             print('  {}'.format(n))
     else:
-        check_call(['./generate.py', args.toml.name, '--verify', '--sol', '-p'] + names + args.args)
+        check_call(['./generate.py', args.toml.name, '--verify', '-p'] + names + args.args)

--- a/generate.py
+++ b/generate.py
@@ -335,7 +335,7 @@ class Problem:
             str(self.basedir / 'hash.json'), 'w'), indent=2, sort_keys=True)
 
 
-def generate(problem: Problem, force_generate: bool, rewrite_hash: bool, verify: bool, generate_html: bool):
+def generate(problem: Problem, force_generate: bool, rewrite_hash: bool, verify: bool, generate_html: bool, html_dir: Path):
     # health check
     problem.health_check()
 
@@ -370,7 +370,7 @@ def generate(problem: Problem, force_generate: bool, rewrite_hash: bool, verify:
         problem.check_hashes()
 
     if generate_html:
-        problem.write_html(problem.basedir)
+        problem.write_html(html_dir if html_dir else problem.basedir)
 
 if __name__ == '__main__':
     basicConfig(
@@ -396,8 +396,6 @@ if __name__ == '__main__':
         logger.warning('--nogen is deprecated, because auto skip was implemented')
     if args.sol:
         logger.warning('--sol is deprecated. --sol is also enabled by --verify')
-    if args.htmldir:
-        logger.warning('--htmldir is deprecated. If you want to use it, please make an issue')
     
     libdir = Path.cwd()
     problems = list()  # type: List[Problem]
@@ -425,4 +423,4 @@ if __name__ == '__main__':
         logger.warning('No problems')
 
     for problem in problems:
-        generate(problem, args.ignore_cache, args.refhash, args.verify, args.html)
+        generate(problem, args.ignore_cache, args.refhash, args.verify, args.html, args.htmldir)

--- a/generate.py
+++ b/generate.py
@@ -335,7 +335,7 @@ class Problem:
             str(self.basedir / 'hash.json'), 'w'), indent=2, sort_keys=True)
 
 
-def generate(problem: Problem, force_generate: bool, rewrite_hash: bool, verify: bool, generate_html: bool, html_dir: Path):
+def generate(problem: Problem, force_generate: bool, rewrite_hash: bool, verify: bool, generate_html: bool, html_dir: Union[Path, None]):
     # health check
     problem.health_check()
 
@@ -427,4 +427,5 @@ if __name__ == '__main__':
         Path(args.htmldir).mkdir(exist_ok=True)
 
     for problem in problems:
-        generate(problem, args.ignore_cache, args.refhash, args.verify, args.html, Path(args.htmldir))
+        generate(problem, args.ignore_cache, args.refhash, args.verify, args.html,
+            Path(args.htmldir) if args.htmldir else None)

--- a/generate.py
+++ b/generate.py
@@ -422,5 +422,9 @@ if __name__ == '__main__':
     if len(problems) == 0:
         logger.warning('No problems')
 
+    if args.htmldir:
+        logger.info('make htmldir')
+        Path(args.htmldir).mkdir(exist_ok=True)
+
     for problem in problems:
         generate(problem, args.ignore_cache, args.refhash, args.verify, args.html, Path(args.htmldir))

--- a/generate.py
+++ b/generate.py
@@ -335,86 +335,94 @@ class Problem:
             str(self.basedir / 'hash.json'), 'w'), indent=2, sort_keys=True)
 
 
+def generate(problem: Problem, force_generate: bool, rewrite_hash: bool, verify: bool, generate_html: bool):
+    # health check
+    problem.health_check()
+
+    logger.info('Start {}'.format(problem.basedir.name))
+
+    is_already_generated = problem.is_already_generated()
+
+    problem.generate_params_h()
+
+    if not is_already_generated or force_generate:
+        problem.compile_correct()
+        problem.compile_gens()
+        problem.make_inputs()
+
+    if verify:
+        problem.compile_verifier()
+        problem.verify_inputs()
+        problem.compile_checker()
+
+    if not is_already_generated or force_generate:
+        problem.make_outputs(args.sol)
+
+    if verify:
+        problem.compile_solutions()
+        # TODO: problem.judge_solutions()?
+        for sol in problem.config.get('solutions', []):
+            problem.judge(problem.basedir / 'sol' / sol['name'], sol)
+
+    if rewrite_hash:
+        problem.write_hashes()
+    else:
+        problem.check_hashes()
+
+    if generate_html:
+        problem.write_html(problem.basedir)
+
 if __name__ == '__main__':
     basicConfig(
         level=getenv('LOG_LEVEL', 'DEBUG'),
         format="%(asctime)s %(levelname)s %(name)s : %(message)s"
     )
     parser = argparse.ArgumentParser(description='Testcase Generator')
-    parser.add_argument('toml', type=argparse.FileType('r'), help='Toml File')
+    parser.add_argument('toml', nargs='*', help='Toml File')
     parser.add_argument('-p', '--problem', nargs='*',
                         help='Generate problem', default=[])
-    parser.add_argument('--nogen', action='store_true', help='Skip Generate')
     parser.add_argument('--verify', action='store_true', help='Verify Inputs')
-    parser.add_argument('--sol', action='store_true', help='Solution Test')
     parser.add_argument('--html', action='store_true', help='Generate HTML')
-    parser.add_argument('--htmldir', help='Generate HTML', default=None)
     parser.add_argument('--refhash', action='store_true', help='Refresh Hash')
     parser.add_argument(
         '--ignore-cache', action='store_true', help='Ignore cache')
+
+    parser.add_argument('--nogen', action='store_true', help='Skip Generate')
+    parser.add_argument('--sol', action='store_true', help='Solution Test')
+    parser.add_argument('--htmldir', help='Generate HTML', default=None)
     args = parser.parse_args()
 
-    problems = toml.load(args.toml)
-    libdir = Path(args.toml.name).parent
-    targetprobs = set(args.problem)
-
-    probs = dict()
-
+    if args.nogen:
+        logger.warning('--nogen is deprecated, because auto skip was implemented')
+    if args.sol:
+        logger.warning('--sol is deprecated. --sol is also enabled by --verify')
     if args.htmldir:
-        logger.info('mkdir htmldir')
-        Path(args.htmldir).mkdir(exist_ok=True)
+        logger.warning('--htmldir is deprecated. If you want to use it, please make an issue')
+    
+    libdir = Path.cwd()
+    problems = list()  # type: List[Problem]
 
-    for name in targetprobs:
-        if name not in problems['problems']:
-            logger.error('There is not problem {}'.format(name))
-            exit(1)
-
-    for name, probinfo in sorted(problems['problems'].items(), key=lambda x: x[0]):
-        if targetprobs and name not in targetprobs:
+    for tomlpath in args.toml:
+        tomlfile = toml.load(args.toml)
+        if 'problems' in tomlfile:
+            logger.warning('problems.toml is deprecated')
             continue
-
-        problem = Problem(libdir, libdir / probinfo['dir'])
-        probs[name] = problem
-
-        if name != problem.basedir.name:
-            logger.error('Different ID({}) vs dir({})'.format(
-                name, problem.basedir.name))
+        problems.append(Problem(libdir, Path(tomlpath).parent))
+    
+    for problem_name in args.problem:
+        tomls = list(Path.cwd().glob('**/{}/info.toml'.format(problem_name)))
+        if len(tomls) == 0:
+            logger.error('Cannot find problem: {}'.format(problem_name))
             exit(1)
+        if len(tomls) >= 2:
+            logger.error('Find multi problem dirs: {}'.format(problem_name))
+            exit(1)
+        problem_dir = tomls[0].parent
+        problems.append(Problem(libdir, problem_dir))
+        logger.info('Find problem dir {}'.format(problem_dir))
 
-        # health check
-        problem.health_check()
+    if len(problems) == 0:
+        logger.warning('No problems')
 
-        logger.info('Start {}'.format(probinfo['dir']))
-
-        is_already_generated = problem.is_already_generated()
-
-        problem.generate_params_h()
-
-        if not args.nogen and (not is_already_generated or args.ignore_cache):
-            problem.compile_correct()
-            problem.compile_gens()
-            problem.make_inputs()
-
-        if args.verify:
-            problem.compile_verifier()
-            problem.verify_inputs()
-
-        if args.sol:
-            problem.compile_checker()
-
-        if not args.nogen and (args.sol or not is_already_generated or args.ignore_cache):
-            problem.make_outputs(args.sol)
-
-        if args.sol:
-            problem.compile_solutions()
-            for sol in problem.config.get('solutions', []):
-                problem.judge(problem.basedir / 'sol' / sol['name'], sol)
-
-        if args.refhash:
-            problem.write_hashes()
-        else:
-            problem.check_hashes()
-
-        if args.html:
-            problem.write_html(Path(args.htmldir)
-                               if args.htmldir else problem.basedir)
+    for problem in problems:
+        generate(problem, args.ignore_cache, args.refhash, args.verify, args.html)

--- a/generate.py
+++ b/generate.py
@@ -423,4 +423,4 @@ if __name__ == '__main__':
         logger.warning('No problems')
 
     for problem in problems:
-        generate(problem, args.ignore_cache, args.refhash, args.verify, args.html, args.htmldir)
+        generate(problem, args.ignore_cache, args.refhash, args.verify, args.html, Path(args.htmldir))

--- a/generate_test.py
+++ b/generate_test.py
@@ -7,55 +7,59 @@ from subprocess import PIPE, run
 
 logger = getLogger(__name__)
 
+# test of deprecated feature
+class TestProblemToml(unittest.TestCase):
+    def test_success(self):
+        proc = run(
+            ['./generate.py', 'problems_test.toml', '-p', 'simple_aplusb', '--verify', '--html'])
+        self.assertEqual(proc.returncode, 0)
 
 class TestSuccess(unittest.TestCase):
     def test_success(self):
         proc = run(
-            ['./generate.py', 'problems_test.toml', '-p', 'simple_aplusb', '--verify', '--sol', '--html'])
+            ['./generate.py', '-p', 'simple_aplusb', '--verify', '--html'])
+        self.assertEqual(proc.returncode, 0)
+
+    def test_success_info_toml(self):
+        proc = run(
+            ['./generate.py', 'test/simple_aplusb/info.toml', '--verify', '--html'])
         self.assertEqual(proc.returncode, 0)
 
 
 class TestVerify(unittest.TestCase):
     def test_no_verify(self):
         proc = run(
-            ['./generate.py', 'problems_test.toml', '-p', 'failed_verify'])
+            ['./generate.py', '-p', 'failed_verify'])
         self.assertEqual(proc.returncode, 0)
 
     def test_failed_verify(self):
-        proc = run(['./generate.py', 'problems_test.toml',
-                    '-p', 'failed_verify', '--verify'])
+        proc = run(['./generate.py', '-p', 'failed_verify', '--verify'])
         self.assertNotEqual(proc.returncode, 0)
 
 
 class TestNonExistProblem(unittest.TestCase):
     def test_non_exist_problem(self):
         proc = run(
-            ['./generate.py', 'problems_test.toml', '-p', 'dummy_problem'])
+            ['./generate.py', '-p', 'dummy_problem'])
         self.assertNotEqual(proc.returncode, 0)
 
 
 class TestUnusedExample(unittest.TestCase):
     def test_no_html(self):
         proc = run(
-            ['./generate.py', 'problems_test.toml', '-p', 'unused_example'])
+            ['./generate.py', '-p', 'unused_example'])
         self.assertEqual(proc.returncode, 0)
 
     def test_unused_example(self):
         proc = run(
-            ['./generate.py', 'problems_test.toml', '-p', 'unused_example', '--html'])
+            ['./generate.py', '-p', 'unused_example', '--html'])
         self.assertNotEqual(proc.returncode, 0)
 
 
 class TestUnusedGen(unittest.TestCase):
     def test_unused_gen(self):
         proc = run(
-            ['./generate.py', 'problems_test.toml', '-p', 'unused_gen'])
-        self.assertNotEqual(proc.returncode, 0)
-
-class TestDifferID(unittest.TestCase):
-    def test_unused_gen(self):
-        proc = run(
-            ['./generate.py', 'problems_test.toml', '-p', 'this_is_differ_id'])
+            ['./generate.py', '-p', 'unused_gen'])
         self.assertNotEqual(proc.returncode, 0)
 
 if __name__ == "__main__":


### PR DESCRIPTION
problems.tomlを使わないようにした #239 #238 

以下のような指定方法が可能　今まで通りのも指定可能で、警告を出すようにした

```
./generate.py sample/aplusb/info.toml datastructure/unionfind/info.toml
./generate.py -p aplusb unionfind
```

機能拡充によって使わなくなったフラグをついでにdeprecated

- --nogen: 自動検出が入ったので
- --sol: --verifyで--solもオンにするようにした　共に使うのは開発者で、使うときは両方一気に使うだろうという考えから
- --htmldir: 昔使ってたけど今は特に…　他に使ってる人もいないでしょう

