### PR TITLE
Fixed Counting Primes task language bug

### DIFF
--- a/math/counting_primes/task.md
+++ b/math/counting_primes/task.md
@@ -1,9 +1,9 @@
 ## @{keyword.statement}
 
 @{lang.ja}
-Count the number of primes no more than $N$.
-@{lang.en}
 $N$ 以下の素数の個数を求めてください。
+@{lang.en}
+Count the number of primes no more than $N$.
 @{lang.end}
 
 ## @{keyword.constraints}


### PR DESCRIPTION
The Counting Primes task had the japanese and english language statements switched. This pull request solves the same.