### PR TITLE
Fix info.toml

### DIFF
--- a/math/composition_of_formal_power_series/info.toml
+++ b/math/composition_of_formal_power_series/info.toml
@@ -1,5 +1,6 @@
 title = 'Composition of Formal Power Series'
 timelimit = 10.0
+forum = "https://github.com/yosupo06/library-checker-problems/issues/569"
 
 [[tests]]
     name = "example.in"


### PR DESCRIPTION
Composition of Formal Power Series に forum の項目が抜けていたので追記しました