### PR TITLE
remove python3.5 from ci

### DIFF
--- a/.github/workflows/generate_test.yml
+++ b/.github/workflows/generate_test.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Set up Python 3.5
+      - name: Set up Python 3.6
         uses: actions/setup-python@v1
         with:
-          python-version: 3.5
+          python-version: 3.6
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -28,10 +28,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Set up Python 3.5
+      - name: Set up Python 3.6
         uses: actions/setup-python@v1
         with:
-          python-version: 3.5
+          python-version: 3.6
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Set up Python 3.5
-        uses: actions/setup-python@v1
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v2
         with:
-          python-version: 3.5
+          python-version: '3.x'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -40,10 +40,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Set up Python 3.5
-        uses: actions/setup-python@v1
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v2
         with:
-          python-version: 3.5
+          python-version: '3.x'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -71,10 +71,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Set up Python 3.5
-        uses: actions/setup-python@v1
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v2
         with:
-          python-version: 3.5
+          python-version: '3.x'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Source code of [https://judge.yosupo.jp](https://judge.yosupo.jp). You can get t
 ## Requirements
 
 - Linux / OS X / Windows(MinGW-w64)
-- python3.5+
+- python3.6+
 - g++ / clang++ (Needs --std=c++14 and __int128_t)
 
 ## How to Use


### PR DESCRIPTION
Python3.5はもうサポートが切れているので、このプロジェクトでも動作保証外ということにします

fix #588 