### PR TITLE
fix statement of bitwise_xor_convolution

### DIFF
--- a/math/bitwise_xor_convolution/task.md
+++ b/math/bitwise_xor_convolution/task.md
@@ -3,9 +3,9 @@
 @{lang.en}
 Given size $2^N$ integer sequences $a_0, a_1, \dots, a_{2^N - 1}$ and $b_0, b_1, \dots, b_{2^N - 1}$. Calculate an integer sequence $c_0, c_1, \dots, c_{2^N - 1}$ as follows and print it $\bmod @{param.MOD}$.
 
-$c_k = \sum_{i, j, i \^ j = k} a_i b_j$
+$c_k = \sum_{i, j, i \oplus j = k} a_i b_j$
 
-We note that $i \^ j$ means bitwise-XOR.
+We note that $i \oplus j$ means bitwise-XOR.
 
 @{lang.ja}
 長さ $2^N$ の整数列 $a_0, a_1, \dots, a_{2^N - 1}$, $b_0, b_1, \dots, b_{2^N - 1}$ が与えられます。以下の数列 $c_0, c_1, \dots, c_{2^N - 1}$ を $\bmod @{param.MOD}$ で計算してください。


### PR DESCRIPTION
#622 

\^ では^は表示できないっぽい。XORの表記法としてはoplusが一般的だと思うので変更