### PR TITLE
Don't run .github/workflows/deploy.yml on fork repositories by default

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,3 +43,4 @@ jobs:
           MINIO_ACCESS_KEY: ${{ secrets.MINIO_ACCESS_KEY }}
           MINIO_SECRET_KEY: ${{ secrets.MINIO_SECRET_KEY }}
           MINIO_BUCKET: ${{ secrets.MINIO_BUCKET }}
+        if: ${{ env.API_PASS != '' }}  # Don't run on fork repositories by default


### PR DESCRIPTION
fork 先で deploy.yml が走って失敗するとコントリビュータが不安になるので、secrets が設定されてないときはスキップするようにします

- 実行例: https://github.com/kmyk/library-checker-problems/runs/3454468214
- 文脈: https://twitter.com/noshi91/status/1431929549445484547