### PR TITLE
add include stdint.h

### DIFF
--- a/datastructure/dynamic_tree_vertex_set_path_composite/sol/correct.cpp
+++ b/datastructure/dynamic_tree_vertex_set_path_composite/sol/correct.cpp
@@ -5,6 +5,8 @@
 #include <stack>
 #include <utility>
 #include <vector>
+#include <stdint.h>
+
 #define REP(i, n) for (int i = 0; (i) < (int)(n); ++ (i))
 #define REP3(i, m, n) for (int i = (m); (i) < (int)(n); ++ (i))
 #define REP_R(i, n) for (int i = (int)(n) - 1; (i) >= 0; -- (i))


### PR DESCRIPTION
In my environment (Ubuntu), uint_fast64_t cannot be used without including stdint.h .
Also, many other correct.cpp contains include stdint.h. So, it should be included. 