### PR TITLE
[datastructure/associative_array] Add max_many_updates

### DIFF
--- a/datastructure/associative_array/gen/max_many_updates.cpp
+++ b/datastructure/associative_array/gen/max_many_updates.cpp
@@ -1,0 +1,31 @@
+#include <iostream>
+#include <vector>
+#include <tuple>
+#include "random.h"
+#include "../params.h"
+using namespace std;
+
+int main(int, char* argv[]) {
+
+    long long seed = atoll(argv[1]);
+    auto gen = Random(seed);
+
+    int Q = Q_MAX;
+    printf("%d\n", Q);
+    vector<long long> keys = { 0LL };
+    
+    for (int i = 0; i < Q; i++) {
+        bool type = gen.uniform(0, 99) == 0;
+        if (!type) {
+            long long key = gen.uniform(0LL, K_AND_V_MAX);
+            long long val = gen.uniform(0LL, K_AND_V_MAX);
+            printf("0 %lld %lld\n", key, val);
+            keys.push_back(key);
+        } else {
+            long long key = keys[gen.uniform(0, (int) keys.size() - 1)];
+            printf("1 %lld\n", key);
+        }
+    }
+    
+    return 0;
+}

--- a/datastructure/associative_array/hash.json
+++ b/datastructure/associative_array/hash.json
@@ -7,6 +7,8 @@
   "many_0set_00.out": "2e08197177cabbde372365ce51f966af78aed94128e1193a2294f5b13b14af9a",
   "many_0set_sparse_00.in": "9984d8acc8dcfa1a613bc20f73a940926cb822b505df8d84dad8ac9cce76006a",
   "many_0set_sparse_00.out": "3acfa7b16f91f4bf2fb326ecb09072303e999b17fe8830828183056f4055ff3f",
+  "max_many_updates_00.in": "77e25b2d16b00854ebc48bf8d7e22b07b04e86543c4dd13834b45fc9cb67428c",
+  "max_many_updates_00.out": "3c004dbece71e0719a38eea36df68cd4998e668c59fad0139e4b4109b759c8bc",
   "max_random_00.in": "ddb9396b57e0c10e47b3afa4da39fb514ebc571db2d666e9592d72b652dc7852",
   "max_random_00.out": "e253ab2277192f84b630c7ca47d33fa82d403e14e6b3200b86bf799a20fe5ba2",
   "max_random_01.in": "ecc81e36056a495ce8fb04b497339b9dd0fb7227adea8c710134a8000ee27dd0",

--- a/datastructure/associative_array/info.toml
+++ b/datastructure/associative_array/info.toml
@@ -12,6 +12,9 @@ forum = 'https://github.com/yosupo06/library-checker-problems/issues/376'
     name = "max_random.cpp"
     number = 3
 [[tests]]
+    name = "max_many_updates.cpp"
+    number = 1
+[[tests]]
     name = "unordered_map_killer.cpp"
     number = 3
 [[tests]]


### PR DESCRIPTION
多くの場合insertたくさんした方が遅くなるので追加しました
ついでにfastestにいる怪しいの(最大サイズを1 << 19にしている)が落ちると思います
