### PR TITLE
Fix windows

### DIFF
--- a/datastructure/point_set_range_sort_range_composite/sol/correct.cpp
+++ b/datastructure/point_set_range_sort_range_composite/sol/correct.cpp
@@ -1,5 +1,6 @@
 #include <cstdio>
 #include <vector>
+#include <tuple>
 #include <cassert>
 #include <algorithm>
 

--- a/math/primitive_root/checker.cpp
+++ b/math/primitive_root/checker.cpp
@@ -1,6 +1,7 @@
 #include "testlib.h"
 
 #include <vector>
+#include <tuple>
 #include <cassert>
 using namespace std;
 using ll = long long;
@@ -207,7 +208,7 @@ int main(int argc, char *argv[]) {
     ll p = inf.readLong();
     ll r = ouf.readLong(0, p - 1);
     if (!check_primitive_root(p, r)) {
-      quitf(_wa, "'%lld' is not a primitive root modulo '%lld'", r, p);
+      quitf(_wa, I64 " is not a primitive root modulo " I64, r, p);
     }
   }
 


### PR DESCRIPTION
Windows の MinGW でビルドできなかったものを修正しました。

## point_set_range_sort_range_composite
よくわからないですが、Linux では暗黙的に入る `#include <tuple>`  がないみたいです。

## primitive_root
quitf では `%lld` を使わない規約に準拠

https://github.com/yosupo06/library-checker-problems/blob/01b6caa7330755e228f1a6669bc83c8a3cf6da6f/docs/guideline.md?plain=1#L119
https://github.com/yosupo06/library-checker-problems/blob/01b6caa7330755e228f1a6669bc83c8a3cf6da6f/docs/guideline.en.md?plain=1#L109