### PR TITLE
Fix toml.load

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -77,7 +77,7 @@ def main(args: List[str]):
     problems: List[Problem] = list()
 
     for tomlpath in opts.toml:
-        tomlfile = toml.load(opts.toml)
+        _ = toml.load(tomlpath)  # validate toml
         problems.append(Problem(rootdir, Path(tomlpath).parent))
 
     for problem_name in opts.problem:

--- a/generate.py
+++ b/generate.py
@@ -77,7 +77,6 @@ def main(args: List[str]):
     problems: List[Problem] = list()
 
     for tomlpath in opts.toml:
-        _ = toml.load(tomlpath)  # validate toml
         problems.append(Problem(rootdir, Path(tomlpath).parent))
 
     for problem_name in opts.problem:


### PR DESCRIPTION
`$(find . -name info.toml)` を引数に渡すと異常に遅くなります。
`tomlfile = toml.load(opts.toml)` なので毎回全ファイルを読み込んでいるようです。

~~バリデーション目的のはずなので一つ一つ読み込むのが良さそうです。~~ 
`Problem.__init__` で toml のバリデーションも済むので、この `toml.load` は全く不要そうです。