### PR TITLE
Fix checking WSL

### DIFF
--- a/problem.py
+++ b/problem.py
@@ -54,7 +54,7 @@ def compile(src: Path, rootdir: Path):
             # avoid conflicts in CI
             # https://github.com/actions/virtual-environments/issues/5459
             cxxflags_default += ' -static'
-        if platform.uname().system == 'Linux' and 'Microsoft' in platform.uname().release:
+        if platform.uname().system == 'Linux' and 'microsoft' in platform.uname().release.lower():
             # a workaround for the lack of ulimit in Windows Subsystem for Linux
             cxxflags_default += ' -fsplit-stack'
         cxxflags = getenv('CXXFLAGS', cxxflags_default).split()


### PR DESCRIPTION
`platform.uname()` の結果は 

```
uname_result(system='Linux', node='NAME', release='5.10.102.1-microsoft-standard-WSL2', version='#1 SMP Wed Mar 2 00:30:59 UTC 2022', machine='x86_64')
```

なので `Microsoft` でなく `microsoft` としなければヒットしません。