### PR TITLE
Composition of FPS の想定解用プログラムが同じ計算を 2 回しているのを解消する

### DIFF
--- a/math/composition_of_formal_power_series/sol/correct.cpp
+++ b/math/composition_of_formal_power_series/sol/correct.cpp
@@ -455,7 +455,6 @@ int main(){
     for(int i=0;i<n;++i)cin>>f[i];
     for(int i=0;i<n;++i)cin>>g[i];
     auto p=f.manipulate(g,n);
-    auto q=f.manipulate(g,n);
     p.resize(n,0);
     for(int i=0;i<n;++i)cout<<p[i]<<" \n"[i==n-1];
 }


### PR DESCRIPTION
https://github.com/yosupo06/library-checker-problems/blob/276d844a394a51a4526b18e13f92f75f894017e6/math/composition_of_formal_power_series/sol/correct.cpp#L457-L460

上に引用したコードの 458 行目を削除します。

出力は変わっていません。