### PR TITLE
gcc13 requires include `<cstdint>` for `uint64_t`

### DIFF
--- a/common/testlib.h
+++ b/common/testlib.h
@@ -181,7 +181,7 @@ const char *latestFeatures[] = {
 #include <stdarg.h>
 #include <fcntl.h>
 #include <functional>
-#include <cstdint>
+#include <cstdint> // modified for library-checker
 
 #ifdef TESTLIB_THROW_EXIT_EXCEPTION_INSTEAD_OF_EXIT
 #   include <exception>

--- a/common/testlib.h
+++ b/common/testlib.h
@@ -181,6 +181,7 @@ const char *latestFeatures[] = {
 #include <stdarg.h>
 #include <fcntl.h>
 #include <functional>
+#include <cstdint>
 
 #ifdef TESTLIB_THROW_EXIT_EXCEPTION_INSTEAD_OF_EXIT
 #   include <exception>


### PR DESCRIPTION
g++ 13 では、 testlib の場合、 `uint64_t` の使用に 標準ライブラリヘッダ [`<cstdint>`](https://ja.cppreference.com/w/cpp/header/cstdint) のインクルードが必須となったようです。（ g++ 12以前でも何らかの他のインクルードファイルを経由して `<cstdint>` が読み込まれていたのだと推測していますが、それが無くなったのかもしれません。）
私の環境の一つ (Archlinux) では、最近 gcc が 13 に更新されたためこの影響を受けたようです。

- https://archlinux.org/packages/core/x86_64/gcc/
- https://github.com/archlinux/svntogit-packages/commits/packages/gcc/trunk

テスト手順例 (Docker + Archlinux):

```
docker run -it --rm archlinux:base-devel-20230430.0.146624
```

```
# git のインストール
pacman -Sy --noconfirm git

# 変更前コードのcheckout
# https://github.com/yosupo06/library-checker-problems/tree/cb2911f7c42bf40caf8d7ca719537dccf7b18aaf
mkdir -p ~/library-checker-problems
cd ~/library-checker-problems
git init
git remote add origin https://github.com/yosupo06/library-checker-problems.git
git fetch --depth 1 origin cb2911f7c42bf40caf8d7ca719537dccf7b18aaf
git checkout FETCH_HEAD

# g++ のバージョン確認
## gcc version 12.2.1 20230201 (GCC)
g++ -v

# ビルドテスト (正常終了)
g++ -O2 -std=c++17 -Wall -Wextra -Werror -Wno-unused-result -I ~/library-checker-problems/common -o ~/library-checker-problems/sample/many_aplusb/checker ~/library-checker-problems/sample/many_aplusb/checker.cpp

# clang のインストール、 gcc の更新
pacman -Sy --noconfirm clang gcc

# g++ のバージョン確認
## gcc version 13.1.1 20230429 (GCC)
g++ -v

# clang++ のバージョン確認
## clang version 15.0.7
clang++ -v

# ビルドテスト (エラー)
g++ -O2 -std=c++17 -Wall -Wextra -Werror -Wno-unused-result -I ~/library-checker-problems/common -o ~/library-checker-problems/sample/many_aplusb/checker ~/library-checker-problems/sample/many_aplusb/checker.cpp

# ビルドテスト (エラー)
clang++ -O2 -std=c++17 -Wall -Wextra -Werror -Wno-unused-result -I ~/library-checker-problems/common -o ~/library-checker-problems/sample/many_aplusb/checker ~/library-checker-problems/sample/many_aplusb/checker.cpp

# 提案コードのcheckout
git fetch --depth 1 origin 4c8c3ad4d34085c42b6cc887c9a6b969e4f1af4f
git checkout FETCH_HEAD

# ビルドテスト (正常終了)
g++ -O2 -std=c++17 -Wall -Wextra -Werror -Wno-unused-result -I ~/library-checker-problems/common -o ~/library-checker-problems/sample/many_aplusb/checker ~/library-checker-problems/sample/many_aplusb/checker.cpp

# ビルドテスト (正常終了)
clang++ -O2 -std=c++17 -Wall -Wextra -Werror -Wno-unused-result -I ~/library-checker-problems/common -o ~/library-checker-problems/sample/many_aplusb/checker ~/library-checker-problems/sample/many_aplusb/checker.cpp
```

テスト手順例 (Docker + Ubuntu 23.04 + g++-13):

```
docker run -it --rm ubuntu:23.04
```

```
# ミラーサイトからパッケージを取得する場合、以下の `sed` を実行
# ca-certificates パッケージをインストールする前に https ミラーサイトに接続すると
# `No system certificates available. Try installing ca-certificates.` と警告が発生するので留意）
## sed -i.bak -r 's!(deb|deb-src) \S+!\1 mirror://mirrors.ubuntu.com/mirrors.txt!' /etc/apt/sources.list

apt update

apt install -y ca-certificates

apt install -y clang-13 clang-14 clang-15 clang-16 g++-12 g++-13 git

# g++-12 のバージョン確認
## gcc version 12.2.0 (Ubuntu 12.2.0-17ubuntu1)
g++-12 -v

# g++-13 のバージョン確認
## gcc version 13.0.1 20230320 (experimental) [master r13-6759-g5194ad1958c] (Ubuntu 13-20230320-1ubuntu1)
g++-13 -v

# clang++-13 のバージョン確認
## Ubuntu clang version 13.0.1-11ubuntu14
clang++-13 -v

# clang++-14 のバージョン確認
## Ubuntu clang version 14.0.6
clang++-14 -v

# clang++-15 のバージョン確認
## Ubuntu clang version 15.0.7
clang++-15 -v

# clang++-16 のバージョン確認
## Ubuntu clang version 16.0.0 (1~exp5ubuntu3)
clang++-16 -v

# 変更前コードのcheckout
# https://github.com/yosupo06/library-checker-problems/tree/cb2911f7c42bf40caf8d7ca719537dccf7b18aaf
mkdir -p ~/library-checker-problems
cd ~/library-checker-problems
git init
git remote add origin https://github.com/yosupo06/library-checker-problems.git
git fetch --depth 1 origin cb2911f7c42bf40caf8d7ca719537dccf7b18aaf
git checkout FETCH_HEAD

# ビルドテスト (正常終了)
g++-12 -O2 -std=c++17 -Wall -Wextra -Werror -Wno-unused-result -I ~/library-checker-problems/common -o ~/library-checker-problems/sample/many_aplusb/checker ~/library-checker-problems/sample/many_aplusb/checker.cpp

# ビルドテスト (エラー)
g++-13 -O2 -std=c++17 -Wall -Wextra -Werror -Wno-unused-result -I ~/library-checker-problems/common -o ~/library-checker-problems/sample/many_aplusb/checker ~/library-checker-problems/sample/many_aplusb/checker.cpp

# ビルドテスト (エラー) Ubuntu 23.04 の場合は clang++-13, clang++-14, clang++-15 でも同様にエラー
## Ubuntu 22.04 の clang++-13, clang++-14, clang++-15 ではエラーは出ない
clang++-16 -O2 -std=c++17 -Wall -Wextra -Werror -Wno-unused-result -I ~/library-checker-problems/common -o ~/library-checker-problems/sample/many_aplusb/checker ~/library-checker-problems/sample/many_aplusb/checker.cpp

# 提案コードのcheckout
# https://github.com/yosupo06/library-checker-problems/tree/4c8c3ad4d34085c42b6cc887c9a6b969e4f1af4f
git fetch --depth 1 origin 4c8c3ad4d34085c42b6cc887c9a6b969e4f1af4f
git checkout FETCH_HEAD

# ビルドテスト (正常終了)
g++-12 -O2 -std=c++17 -Wall -Wextra -Werror -Wno-unused-result -I ~/library-checker-problems/common -o ~/library-checker-problems/sample/many_aplusb/checker ~/library-checker-problems/sample/many_aplusb/checker.cpp

# ビルドテスト (正常終了)
g++-13 -O2 -std=c++17 -Wall -Wextra -Werror -Wno-unused-result -I ~/library-checker-problems/common -o ~/library-checker-problems/sample/many_aplusb/checker ~/library-checker-problems/sample/many_aplusb/checker.cpp

# ビルドテスト (正常終了)
clang++-16 -O2 -std=c++17 -Wall -Wextra -Werror -Wno-unused-result -I ~/library-checker-problems/common -o ~/library-checker-problems/sample/many_aplusb/checker ~/library-checker-problems/sample/many_aplusb/checker.cpp
```

エラー出力例 (g++ 13):

```
In file included from /root/library-checker-problems/sample/many_aplusb/checker.cpp:25:
/root/library-checker-problems/common/testlib.h: In member function 'std::vector<T> random_t::distinct(int, T, T)':
/root/library-checker-problems/common/testlib.h:1136:9: error: 'uint64_t' was not declared in this scope
 1136 |         uint64_t n = to - from + 1;
      |         ^~~~~~~~
/root/library-checker-problems/common/testlib.h:207:1: note: 'uint64_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
  206 | #   include <unistd.h>
  +++ |+#include <cstdint>
  207 | #endif
/root/library-checker-problems/common/testlib.h:1137:30: error: 'n' was not declared in this scope
 1137 |         if (uint64_t(size) > n)
      |                              ^
/root/library-checker-problems/common/testlib.h:1142:32: error: 'n' was not declared in this scope
 1142 |             expected += double(n) / double(n - i + 1);
      |                                ^
/root/library-checker-problems/common/testlib.h:1144:31: error: 'n' was not declared in this scope
 1144 |         if (expected < double(n)) {
      |                               ^
```

エラー出力例 (clang++ 15):

```
In file included from /root/library-checker-problems/sample/many_aplusb/checker.cpp:25:
/root/library-checker-problems/common/testlib.h:1136:9: error: unknown type name 'uint64_t'
        uint64_t n = to - from + 1;
        ^
/root/library-checker-problems/common/testlib.h:1137:13: error: use of undeclared identifier 'uint64_t'
        if (uint64_t(size) > n)
            ^
2 errors generated.
```