### PR TITLE
Fix -Werror=type-limits

### DIFF
--- a/common/testlib.h
+++ b/common/testlib.h
@@ -3049,7 +3049,7 @@ void InStream::xmlSafeWrite(std::FILE *file, const char *msg) {
             std::fprintf(file, "%s", "&quot;");
             continue;
         }
-        if (0 <= msg[i] && msg[i] <= 31) {
+        if (msg[i] <= 31) { // modified for library-checker
             std::fprintf(file, "%c", '.');
             continue;
         }


### PR DESCRIPTION
`./generate.py -p unionfind` を実行すると次のエラーが出ました。

```
root@02371d4f3798:/library-checker-problems# ./generate.py -p unionfind
12:42:55 [INFO] Start unionfind
12:42:55 [INFO] generate params.h
12:42:55 [INFO] compile checker
In file included from /library-checker-problems/datastructure/unionfind/checker.cpp:25:
/library-checker-problems/common/testlib.h: In member function ‘void InStream::xmlSafeWrite(FILE*, const char*)’:
/library-checker-problems/common/testlib.h:3052:15: error: comparison is always true due to limited range of data type [-Werror=type-limits]
 3052 |         if (0 <= msg[i] && msg[i] <= 31) {
      |             ~~^~~~~~~~~
cc1plus: all warnings being treated as errors
Traceback (most recent call last):
  File "/library-checker-problems/./generate.py", line 115, in <module>
    main(sys.argv[1:])
  File "/library-checker-problems/./generate.py", line 112, in main
    problem.generate(mode, Path(opts.htmldir) if opts.htmldir else None)
  File "/library-checker-problems/problem.py", line 514, in generate
    self.compile_checker()
  File "/library-checker-problems/problem.py", line 188, in compile_checker
    compile(self.checker, self.rootdir)
  File "/library-checker-problems/problem.py", line 62, in compile
    check_call(args)
  File "/usr/lib/python3.10/subprocess.py", line 369, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['g++', '-O2', '-std=c++17', '-Wall', '-Wextra', '-Werror', '-Wno-unused-result', '-I', '/library-checker-problems/common', '-o', '/library-checker-problems/datastructure/unionfind/checker', '/library-checker-problems/datastructure/unionfind/checker.cpp']' returned non-zero exit status 1.
```

char型は処理系によって符号値きかそうでないかが変わるようです。
使用した環境(ubuntu on docker on m1 mac)では符号なしとして処理されるためか、上記のエラーが出てると考えられます。

エラーとなっている `testlib.h:3052` のコードの意図は「普通の文字」ではない文字を `.` とする、というものだと推測しました。そして「普通の文字」は ASCIIコード 32 以降の文字だと思います。
従って、この条件分岐は `msg[i] <= 31` のみで目的を十分に果たせると考えられます。

gccにはcharを符号付きにするかしないかを選べるコンパイルオプションが存在するようですが、上に書いたとおり、今回の目的においてはそのコンパイルオプションは不要であり、`0 <= msg[i]`の判定を消すことでエラーを解消できると考えました。