### PR TITLE
fix stack-size option for apple silicon

### DIFF
--- a/problem.py
+++ b/problem.py
@@ -47,7 +47,8 @@ def compile(src: Path, rootdir: Path, opts: [str] = []):
         cxx = getenv('CXX', 'g++')
         cxxflags_default = '-O2 -std=c++17 -Wall -Wextra -Werror -Wno-unused-result'
         if platform.system() == 'Darwin':
-            cxxflags_default += ' -Wl,-stack_size,{}'.format(hex(STACK_SIZE))
+            if platform.processor() != 'arm':
+                cxxflags_default += ' -Wl,-stack_size,{}'.format(hex(STACK_SIZE))
         if platform.system() == 'Windows':
             cxxflags_default += ' -Wl,-stack,{}'.format(hex(STACK_SIZE))
             # avoid using MinGW's "unique" stdio, which doesn't recognize %lld

--- a/problem.py
+++ b/problem.py
@@ -47,8 +47,7 @@ def compile(src: Path, rootdir: Path, opts: [str] = []):
         cxx = getenv('CXX', 'g++')
         cxxflags_default = '-O2 -std=c++17 -Wall -Wextra -Werror -Wno-unused-result'
         if platform.system() == 'Darwin':
-            if platform.processor() != 'arm':
-                cxxflags_default += ' -Wl,-stack_size,{}'.format(hex(STACK_SIZE))
+            cxxflags_default += ' -Wl,-stack_size,{}'.format(hex(STACK_SIZE))
         if platform.system() == 'Windows':
             cxxflags_default += ' -Wl,-stack,{}'.format(hex(STACK_SIZE))
             # avoid using MinGW's "unique" stdio, which doesn't recognize %lld

--- a/problem.py
+++ b/problem.py
@@ -23,7 +23,7 @@ import toml
 logger = getLogger(__name__)  # type: Logger
 
 CASENAME_LEN_LIMIT = 40
-STACK_SIZE = 2 ** 31  # 2GB
+STACK_SIZE = 2 ** 28  # 256 MB
 
 
 def casename(name: Union[str, Path], i: int) -> str:


### PR DESCRIPTION
https://github.com/yosupo06/library-checker-problems/issues/988 に関連してのPR

一旦 m1 mac以外は関係なさそうな問題なので、m1 macの時だけstack sizeのオプションを入れなければとりあえず動きそうだったので修正PRです。


m1 macかどうか、は下記の感じで拾えそうでした。
```
 >>> platform.processor()
'arm'
```
https://stackoverflow.com/questions/65970469/what-does-platform-system-and-platform-architecture-return-on-apple-m1-silic

修正方向が微妙だったらすみません。


