### PR TITLE
include cstdint to make INT64_MAX visible

### DIFF
--- a/datastructure/range_chmin_chmax_add_range_sum/sol/correct.cpp
+++ b/datastructure/range_chmin_chmax_add_range_sum/sol/correct.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <cassert>
+#include <cstdint>
 #include <iostream>
 #include <vector>
 #define REP(i, n) for (int i = 0; (i) < (int)(n); ++ (i))


### PR DESCRIPTION
When I tried to compile it with `./generate.py -p range_chmin_chmax_add_range_sum`, I got a bunch of errors complaining about INT64_MAX usage in this file. Include cstdint fixes this.