### PR TITLE
bug fix: seed * q -> seed * q + i

### DIFF
--- a/math/factorize/gen/prime_test_special_bug.cpp
+++ b/math/factorize/gen/prime_test_special_bug.cpp
@@ -51,8 +51,8 @@ int main(int, char* argv[]) {
     int q = MAX_Q;
     printf("%d\n", q);
     for (int i = 0; i < q; i++) {
-        int pos = seed * q;
-        printf("%lld\n", list[pos % int(buf.size())]);
+        int pos = seed * q + i;
+        printf("%lld\n", list[pos % int(list.size())]);
     }
     return 0;
 }


### PR DESCRIPTION
If we use pos = seed * q, it will generate same number of each test case.