### PR TITLE
Fixed issue with the generator `near_65536.cpp` in Kth term of Linearly Recurrent Sequence 

### DIFF
--- a/math/kth_term_of_linearly_recurrent_sequence/gen/near_65536.cpp
+++ b/math/kth_term_of_linearly_recurrent_sequence/gen/near_65536.cpp
@@ -9,7 +9,21 @@ int main(int, char* argv[]) {
     long long seed = atoll(argv[1]);
     auto gen = Random(seed);
 
-    long long d = 65535 + gen.uniform<int>(0, 2);
+    // https://github.com/yosupo06/library-checker-problems/pull/1069#discussion_r1429047154
+
+    // Consume the same number of random numbers as in the original case
+    gen.uniform<int>(0, 2);
+
+    // Correspondence between seeds and d in the original test cases:
+    //                       seed     d                              
+    //                      ==============                           
+    //                        0     65535                            
+    //                        1     65536                            
+    //                        2     65537                            
+    //                      --------------                           
+    int a[3]{ 0, 1, 2 };
+
+    long long d = 65535 + a[seed % 3];
     long long k = gen.uniform<long long>(0, K_MAX);
 
     printf("%lld %lld\n", d, k);


### PR DESCRIPTION
https://github.com/yosupo06/library-checker-problems/pull/1069#discussion_r1423568341