### PR TITLE
make the python scripts work in msys2 environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Source code of [https://judge.yosupo.jp](https://judge.yosupo.jp). You can get t
 
 - Linux / OS X / Windows(MinGW-w64)
 - python3.6+
-- g++ / clang++ (Needs --std=c++14 and __int128_t)
+- g++ / clang++ (Needs --std=c++17 and __int128_t)
 
 ## How to Use
 


### PR DESCRIPTION
According to <https://www.msys2.org/docs/python/>, I added some code to tell if we are in msys2 environment and use the proper compiler for it and it works. 

I also changed the requirement in README.md because we use `-std=c++17` in the python script.

By the way I don't have a computer runs with Linux or Mach, so I didn't test.

It seems possible to add some workflow for msys2.

<img width="1920" alt="image" src="https://github.com/yosupo06/library-checker-problems/assets/50443487/4a3b0793-4596-4059-b396-cdecb06c2262">

<img width="1920" alt="屏幕截图 2024-01-15 195145" src="https://github.com/yosupo06/library-checker-problems/assets/50443487/64a7d9af-b59c-4941-b093-adb3574aaca2">
