### PR TITLE
括弧 {} のコマンドの変更

### DIFF
--- a/datastructure/persistent_unionfind/task.md
+++ b/datastructure/persistent_unionfind/task.md
@@ -16,7 +16,7 @@ $G_{-1}$ を、$N$ 個の頂点からなる、辺がひとつも存在しない�
 
 - $1 \leq N \leq @{param.MAX_N}$
 - $1 \leq Q \leq @{param.MAX_Q}$
-- $t\_{i} \in \left\\{ 0, 1 \right\\}$
+- $t\_{i} \in \left\lbrace 0, 1 \right\rbrace$
 - $-1 \leq k\_{i} < i$
 - for all $k_i$, $k\_i = -1$ or $t\_{k\_{i}} = 0$ holds.
 - $0 \leq u\_{i}, v\_{i} < N$

--- a/graph/chromatic_number/task.md
+++ b/graph/chromatic_number/task.md
@@ -1,12 +1,12 @@
 ## @{keyword.statement}
 
 @{lang.en}
-Given a simple undirected graph with $N$ vertices and $M$ edges. $i$-th edge is $\{u_i, v_i\}$。
+Given a simple undirected graph with $N$ vertices and $M$ edges. $i$-th edge is $\lbrace u_i, v_i\rbrace$。
 
 Calculate the chromatic number $C$.
 
 @{lang.ja}
-$N$ 頂点 $M$ 辺の単純な無向グラフが与えられる。 $i$ 番目の辺は $\{u_i, v_i\}$である。
+$N$ 頂点 $M$ 辺の単純な無向グラフが与えられる。 $i$ 番目の辺は $\lbrace u_i, v_i\rbrace$ である。
 
 彩色数 $C$ を出力してください。
 @{lang.end}
@@ -17,7 +17,7 @@ $N$ 頂点 $M$ 辺の単純な無向グラフが与えられる。 $i$ 番目の
 - $0 \leq M \leq \frac{N(N-1)}{2}$
 - $0 \leq u_i, v_i < N$
 - $u_i \neq v_i$
-- $\{u_i, v_i\} \neq \{u_j, v_j\}$
+- $\lbrace u_i, v_i\rbrace \neq \lbrace u_j, v_j\rbrace$
 
 ## @{keyword.input}
 

--- a/graph/min_cost_b_flow/task.md
+++ b/graph/min_cost_b_flow/task.md
@@ -7,7 +7,7 @@ You are given a directed graph with $n$ vertices and $m$ edges, amount of supply
 The $v$-th vertex has $b_v$ amount of supply if $b_v$ was positive, and $-b_v$ amount of demand otherwise.
 The $e$-th edge is directed from vertex $s_e$ to $t_e$ and has flow lower bound $l_e$, flow upper bound $u_e$, and cost per a unit of flow $c_e$.
 
-Your task is to find and print the minimum cost $\mathbf{b}$-flow value $z$, the flow $\mathbf{f}$ and its dual $\mathbf{p}$ that achives the minimum, that is, $z$, $\mathbf{f} = \\{f_e\\}\_{e = 0 \dots m-1}$, and $\mathbf{p} = \\{p_v\\}\_{v = 0 \dots n-1}$ that satisfies following constraints;
+Your task is to find and print the minimum cost $\mathbf{b}$-flow value $z$, the flow $\mathbf{f}$ and its dual $\mathbf{p}$ that achives the minimum, that is, $z$, $\mathbf{f} = \lbrace f_e\rbrace _ {e = 0 \dots m-1}$, and $\mathbf{p} = \lbrace p_v\rbrace _ {v = 0 \dots n-1}$ that satisfies following constraints;
 
 - $z = \sum_{e} c_e f_e$
 - $l_e \leq f_e \leq u_e$ (Capacity constraints)
@@ -16,7 +16,7 @@ Your task is to find and print the minimum cost $\mathbf{b}$-flow value $z$, the
 - $f_e \lt u_e \Rightarrow c_e + p_{s_e} - p_{t_e} \ge 0$ (Complementary slackness conditions)
 - $|p_v| \le @{param.P_MAX}$
 
-where $\delta^+(v)$ is the set of edges leaving vertex $v$ and $\delta^-(v)$ is the set of edges entering vertex $v$, i.e. $\delta^+(v) = \left\\{ e \relmiddle| s_e = v \right\\}$ and $\delta^-(v) = \left\\{ e \relmiddle| t_e = v \right\\}$.
+where $\delta^+(v)$ is the set of edges leaving vertex $v$ and $\delta^-(v)$ is the set of edges entering vertex $v$, i.e. $\delta^+(v) = \left\lbrace e \relmiddle| s_e = v \right\rbrace$ and $\delta^-(v) = \left\lbrace e \relmiddle| t_e = v \right\rbrace$.
 
 If there's no such values, output "infeasible" instead.
 
@@ -25,7 +25,7 @@ $n$ 頂点 $m$ 辺の有向グラフ, 頂点に付随する需要/供給量, 辺
 $v$ 番目の頂点は, $b_v$ が正のとき $b_v$ の供給点であり, そうでないとき $-b_v$ の需要点です.
 また, $e$ 番目の辺は頂点 $s_e$ から頂点 $t_e$ に張られており, 流量下限 $l_e$, 流量上限 $u_e$, 単位流量あたりのコスト $c_e$ です.
 
-このネットワーク上の最小コスト $z$, それを達成する $\mathbf{b}$-フロー $\mathbf{f}$ と双対変数 $\mathbf{p}$, すなわち次を満たす $z$, $\mathbf{f} = \\{f_e\\}\_{e = 0 \dots m-1}$ と $\mathbf{p} = \\{p_v\\}\_{v = 0 \dots n-1}$ を求めて出力して下さい.
+このネットワーク上の最小コスト $z$, それを達成する $\mathbf{b}$-フロー $\mathbf{f}$ と双対変数 $\mathbf{p}$, すなわち次を満たす $z$, $\mathbf{f} = \lbrace f_e\rbrace _ {e = 0 \dots m-1}$ と $\mathbf{p} = \lbrace p_v\rbrace _ {v = 0 \dots n-1}$ を求めて出力して下さい.
 そのようなものが存在しないならば, "infeasible" と出力してください.
 
 - $z = \sum_{e} c_e f_e$
@@ -35,7 +35,7 @@ $v$ 番目の頂点は, $b_v$ が正のとき $b_v$ の供給点であり, そ�
 - $f_e \lt u_e \Rightarrow c_e + p_{s_e} - p_{t_e} \ge 0$ (相補性条件)
 - $|p_v| \le @{param.P_MAX}$
 
-ここで, $\delta^+(v)$ は $v$ から出る辺全体の集合 $\left\\{ e \relmiddle| s_e = v \right\\}$, $\delta^-(v)$ は $v$ へ入る辺全体の集合 $\left\\{ e \relmiddle| t_e = v \right\\}$ です.
+ここで, $\delta^+(v)$ は $v$ から出る辺全体の集合 $\left\lbrace e \relmiddle| s_e = v \right\rbrace$, $\delta^-(v)$ は $v$ へ入る辺全体の集合 $\left\lbrace e \relmiddle| t_e = v \right\rbrace$ です.
 @{lang.end}
 
 ## @{keyword.constraints}

--- a/math/enumerate_primes/task.md
+++ b/math/enumerate_primes/task.md
@@ -20,7 +20,7 @@ $p_{Ai+B} \le N$ を満たす各非負整数 $i$ に対して $p_{Ai+B}$ を出�
 
 - $@{param.N_MIN} \le N \le @{param.N_MAX}$
 - $0 \le B < A \le N$
-- $@{param.X_MIN} \le X \le @{param.X_MAX}$ where $X = \\#\\{ i \in \mathbb{Z}\_{\ge 0} \mid p_{Ai+B} \le N \\}$
+- $@{param.X_MIN} \le X \le @{param.X_MAX}$ where $X = \\#\lbrace i \in \mathbb{Z}\_{\ge 0} \mid p_{Ai+B} \le N \rbrace$
 
 ## @{keyword.input}
 

--- a/math/nim_product_64/task.md
+++ b/math/nim_product_64/task.md
@@ -6,8 +6,8 @@ Calculate the nim product $A \otimes B$.
 
 The nim sum and the nim product for nonnegative integers are defined recursively as follows:
 
-- $a \oplus b = \operatorname{mex}(\\{ a' \oplus b \mid a' < a \\} \cup \\{ a \oplus b' \mid b' < b \\})$
-- $a \otimes b = \operatorname{mex}\\{ (a' \otimes b) \oplus (a \otimes b') \oplus (a' \otimes b') \mid a' < a,\, b' < b \\}$
+- $a \oplus b = \operatorname{mex}(\lbrace a' \oplus b \mid a' < a \rbrace \cup \lbrace a \oplus b' \mid b' < b \rbrace)$
+- $a \otimes b = \operatorname{mex}\lbrace (a' \otimes b) \oplus (a \otimes b') \oplus (a' \otimes b') \mid a' < a,\, b' < b \rbrace$
 
 ## @{keyword.constraints}
 

--- a/math/sharp_p_subset_sum/task.md
+++ b/math/sharp_p_subset_sum/task.md
@@ -3,11 +3,11 @@
 @{lang.en}
 Given $N$ positive integers $s_0,s_1,\ldots,s_{N-1}$ and a positive integer $T$.
 
-For each $t=1,2,...,T$, count the number of subset $I \subseteq \\{0,1,...,N-1\\}$ s.t. $\sum_{i \in I} s_i=t$ and print it $\bmod @{param.MOD}$ (we denote it as $p_t$).
+For each $t=1,2,...,T$, count the number of subset $I \subseteq \lbrace 0,1,...,N-1\rbrace$ s.t. $\sum_{i \in I} s_i=t$ and print it $\bmod @{param.MOD}$ (we denote it as $p_t$).
 @{lang.ja}
 $N$個の正整数 $s_0,s_1,\ldots,s_{N-1}$ と正整数 $T$ が与えられます。
 
-$t=1,2,...,T$ について、部分集合 $I \subseteq \\{0,1,...,N-1\\}$ のうち$\sum_{i \in I} s_i=t$となるものの個数を $@{param.MOD}$ で割った余り $p_t$ を求めてください。
+$t=1,2,...,T$ について、部分集合 $I \subseteq \lbrace 0,1,...,N-1\rbrace$ のうち$\sum_{i \in I} s_i=t$となるものの個数を $@{param.MOD}$ で割った余り $p_t$ を求めてください。
 @{lang.end}
 
 ## @{keyword.constraints}


### PR DESCRIPTION
* `\{` `\}` を使用した問題文ではその括弧が表示されなかったので、 `\lbrace` `\rbrace` を使用するように変更しました。
* 予防的に、 `\\{` `\\}` も `\lbrace` `\rbrace` に変更しました。