### PR TITLE
fix #1094

### DIFF
--- a/math/polynomial_root_finding/task.md
+++ b/math/polynomial_root_finding/task.md
@@ -1,12 +1,12 @@
 ## @{keyword.statement}
 
 @{lang.en}
-Given a polynomial $f(x) = \sum_{i=0}^Nf_ix^i\in \mathbb{F}_{998244353}[x]$ of degree $N$. 
-Find all $a\in \mathbb{F}_{998244353}$ satisfying $f(a)=0$.
+Given a polynomial $f(x) = \sum_{i=0}^Nf _ ix^i\in \mathbb{F} _ {998244353}[x]$ of degree $N$. 
+Find all $a\in \mathbb{F} _ {998244353}$ satisfying $f(a)=0$.
 
 @{lang.ja}
-次数 $N$ の多項式 $f(x) \in \mathbb{F}_{998244353}[x]$ が与えられます．
-$f(a)=0$ を満たす $a\in \mathbb{F}_{998244353}$ をすべて求めてください．
+次数 $N$ の多項式 $f(x) \in \mathbb{F} _ {998244353}[x]$ が与えられます．
+$f(a)=0$ を満たす $a\in \mathbb{F} _ {998244353}$ をすべて求めてください．
 
 @{lang.end}
 


### PR DESCRIPTION
該当部のアンダースコアの両側に半角スペースを入れました。

参考： https://kmyk.github.io/blog/blog/2020/02/19/portable-mathjax-markdown/