### PR TITLE
fix #1092

### DIFF
--- a/graph/general_weighted_matching/task.md
+++ b/graph/general_weighted_matching/task.md
@@ -16,7 +16,7 @@ $N$ 頂点 $M$ 辺からなる単純重み付き無向グラフが与えられ�
 - $1 \leq N \leq 500$
 - $0 \leq M \leq \frac{N(N-1)}{2}$
 - $0 \leq u_i, v_i < N$
-- $1 \leq w_i \leq 1\,000\,000$
+- $1 \leq w_i \leq 1\thinspace 000\thinspace 000$
 
 ## @{keyword.input}
 

--- a/math/nim_product_64/task.md
+++ b/math/nim_product_64/task.md
@@ -7,7 +7,7 @@ Calculate the nim product $A \otimes B$.
 The nim sum and the nim product for nonnegative integers are defined recursively as follows:
 
 - $a \oplus b = \operatorname{mex}(\lbrace a' \oplus b \mid a' < a \rbrace \cup \lbrace a \oplus b' \mid b' < b \rbrace)$
-- $a \otimes b = \operatorname{mex}\lbrace (a' \otimes b) \oplus (a \otimes b') \oplus (a' \otimes b') \mid a' < a,\, b' < b \rbrace$
+- $a \otimes b = \operatorname{mex}\lbrace (a' \otimes b) \oplus (a \otimes b') \oplus (a' \otimes b') \mid a' < a,\thinspace b' < b \rbrace$
 
 ## @{keyword.constraints}
 


### PR DESCRIPTION
`\,` が使われている場所を `\thinspace` で置き換えました。

ref. https://katex.org/docs/supported.html#overlap-and-spacing