### PR TITLE
Fix math/intersection_of_f2_vector_spaces/checker.cpp

### DIFF
--- a/math/intersection_of_f2_vector_spaces/checker.cpp
+++ b/math/intersection_of_f2_vector_spaces/checker.cpp
@@ -4,7 +4,33 @@
 
 #include "params.h"
 #include "testlib.h"
-#include "binary_mat.h"
+
+// Copied from binary_mat.h
+class BinaryMat {
+private:
+    std::vector<int> basis_;
+public:
+    BinaryMat() {}
+    void add(int x) {
+        x = this->sift(x);
+        if (x != 0) {
+            this->basis_.push_back(x);
+        }
+    }
+    int sift(int x) const {
+        for (int b: this->basis_) {
+            x = std::min(x, x ^ b);
+            if (x == 0) return 0;
+        }
+        return x;
+    }
+    bool is_indep(int x) const {
+        return this->sift(x) != 0;
+    }
+    std::vector<int> basis() const {
+        return this->basis_;
+    }
+};
 
 int main(int argc, char* argv[]) {
     registerTestlibCmd(argc, argv);


### PR DESCRIPTION
The judge of https://judge.yosupo.jp/submission/204462 (from https://github.com/yosupo06/library-checker-problems/pull/1132) returned ICE because math/intersection_of_f2_vector_spaces/checker.cpp included a file (`binary_mat.h`) that is not in the list (https://github.com/yosupo06/library-checker-judge/blob/d50e6a18e2ac3f2a093783e92c9e97d38e046a73/uploader/main.go#L52-L100). This PR addresses the issue by copy-pasting the header file `binary_mat.h`.

This PR is confirmed to work in the local environment.