### PR TITLE
chore(ci): update actions version

### DIFF
--- a/.github/workflows/cpp-lib-test.yml
+++ b/.github/workflows/cpp-lib-test.yml
@@ -10,7 +10,7 @@ jobs:
   util-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: run unittest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch Problems Deploy
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.JUDGE_REPO_TOKEN }}
           repository: yosupo06/library-checker-judge

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -29,10 +29,10 @@ jobs:
   generate:
     runs-on: ${{ inputs.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python 3.x
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
       - name: Install dependencies
@@ -41,7 +41,7 @@ jobs:
           pip install --user -r requirements.txt
 
       - name: Restore versions.json
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         if: ${{ !inputs.force-generate }}
         with:
           path: versions.json
@@ -60,7 +60,7 @@ jobs:
           VERSIONS_CACHE_PATH: versions.json
 
       - name: Save versions.json
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: versions.json
           key: ${{ runner.os }}-(${{ inputs.cxx }})-versions-cache-${{ hashFiles('versions.json') }}

--- a/.github/workflows/util_test.yml
+++ b/.github/workflows/util_test.yml
@@ -10,9 +10,9 @@ jobs:
   util-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.x
       - name: Install dependencies


### PR DESCRIPTION
As is shown in Actions, Node.js 16 actions are deprecated. This commit updates all actions to using Node.js 20.

See: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.