### PR TITLE
stop using wrong = True and introduce expect

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,8 @@
 			"extensions": [
 				"llvm-vs-code-extensions.vscode-clangd",
 				"ms-python.python",
-				"github.vscode-github-actions"
+				"github.vscode-github-actions",
+				"tamasfe.even-better-toml"
 			]
 		}
 	}

--- a/datastructure/deque_operate_all_composite/info.toml
+++ b/datastructure/deque_operate_all_composite/info.toml
@@ -26,7 +26,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/815"
 
 [[solutions]]
     name = "bbst.cpp"
-    wrong = false
+    
 [[solutions]]
     name = "naive.cpp"
-    wrong = true
+    expect = "TLE"

--- a/datastructure/double_ended_priority_queue/info.toml
+++ b/datastructure/double_ended_priority_queue/info.toml
@@ -37,12 +37,12 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/874"
 [[solutions]]
     name = "double_priority_queue.cpp"
     allow_tle = false
-    wrong = false
+    
 
 [[solutions]]
     name = "multiset.cpp"
     allow_tle = false
-    wrong = false
+    
 
 [params]
     N_MIN = 0

--- a/datastructure/dynamic_graph_vertex_add_component_sum/info.toml
+++ b/datastructure/dynamic_graph_vertex_add_component_sum/info.toml
@@ -32,7 +32,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/347"
 
 [[solutions]]
 	name = "naive.cpp"
-	wrong = true
+    expect = "TLE"
 	
 
 [params]

--- a/datastructure/dynamic_graph_vertex_add_component_sum/info.toml
+++ b/datastructure/dynamic_graph_vertex_add_component_sum/info.toml
@@ -32,12 +32,12 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/347"
 
 [[solutions]]
 	name = "naive.cpp"
-    expect = "TLE"
-	
+	expect = "TLE"
+
 
 [params]
-	N_AND_Q_MIN = 1
-	N_AND_Q_MAX = 300_000
-	N_AND_Q_SMALL_MAX = 1_000
-	A_AND_X_MIN = 0
-	A_AND_X_MAX = 1_000_000_000
+N_AND_Q_MIN = 1
+N_AND_Q_MAX = 300_000
+N_AND_Q_SMALL_MAX = 1_000
+A_AND_X_MIN = 0
+A_AND_X_MAX = 1_000_000_000

--- a/datastructure/dynamic_sequence_range_affine_range_sum/info.toml
+++ b/datastructure/dynamic_sequence_range_affine_range_sum/info.toml
@@ -28,7 +28,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/242"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = true
+    expect = "RE"
 
 [params]
     N_AND_Q_MAX = 500_000

--- a/datastructure/dynamic_tree_subtree_add_subtree_sum/info.toml
+++ b/datastructure/dynamic_tree_subtree_add_subtree_sum/info.toml
@@ -20,7 +20,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/521"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = true
+    expect = "RE"
 
 [params]
     N_MAX = 200_000

--- a/datastructure/dynamic_tree_vertex_add_path_sum/info.toml
+++ b/datastructure/dynamic_tree_vertex_add_path_sum/info.toml
@@ -20,7 +20,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/223"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = true
+    expect = "TLE"
 
 [params]
     N_AND_Q_MIN = 1

--- a/datastructure/dynamic_tree_vertex_add_subtree_sum/info.toml
+++ b/datastructure/dynamic_tree_vertex_add_subtree_sum/info.toml
@@ -20,7 +20,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/229"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = true
+    expect = "TLE"
 
 [params]
     N_AND_Q_MIN = 1

--- a/datastructure/dynamic_tree_vertex_set_path_composite/info.toml
+++ b/datastructure/dynamic_tree_vertex_set_path_composite/info.toml
@@ -24,7 +24,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/307"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = true
+    expect = "TLE"
 
 [params]
     N_AND_Q_MIN = 1

--- a/datastructure/line_add_get_min/info.toml
+++ b/datastructure/line_add_get_min/info.toml
@@ -26,7 +26,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/174"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = true
+    expect = "RE"
 
 [params]
     N_AND_Q_MIN = 1

--- a/datastructure/number_of_subsequences/info.toml
+++ b/datastructure/number_of_subsequences/info.toml
@@ -33,8 +33,7 @@ forum = 'https://github.com/yosupo06/library-checker-problems/issues/811'
     name = "correct2.cpp"
 [[solutions]]
     name = "naive.cpp"
-    allow_tle = true
-    wrong = true
+    expect = "WA"
 
 [params]
     N_MIN = 1

--- a/datastructure/persistent_queue/info.toml
+++ b/datastructure/persistent_queue/info.toml
@@ -29,10 +29,10 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/379"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = true
+    expect = "TLE"
 [[solutions]]
     name = "two_stacks.cpp"
-    wrong = true
+    expect = "TLE"
 
 [params]
     Q_MIN = 1

--- a/datastructure/persistent_unionfind/info.toml
+++ b/datastructure/persistent_unionfind/info.toml
@@ -20,10 +20,10 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/405"
 
 [[solutions]]
     name = "correct_2.cpp"
-    wrong = false
+    
 [[solutions]]
     name = "conchon_filliatre.cpp"
-    wrong = true
+    expect = "TLE"
 
 [params]
     MAX_N = 200_000

--- a/datastructure/point_set_range_sort_range_composite/info.toml
+++ b/datastructure/point_set_range_sort_range_composite/info.toml
@@ -41,7 +41,6 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/818"
 
 [[solutions]]
     name = "naive.cpp"
-    
     allow_tle = true
 
 [params]

--- a/datastructure/point_set_range_sort_range_composite/info.toml
+++ b/datastructure/point_set_range_sort_range_composite/info.toml
@@ -41,7 +41,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/818"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = false
+    
     allow_tle = true
 
 [params]

--- a/datastructure/predecessor_problem/info.toml
+++ b/datastructure/predecessor_problem/info.toml
@@ -40,12 +40,12 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/632"
 
 [[solutions]]
     name = "fenwick.cpp"
-    wrong = false
+    
     allow_tle = true
 
 [[solutions]]
     name = "set.cpp"
-    wrong = false
+    
     allow_tle = true
 
 [params]

--- a/datastructure/predecessor_problem/info.toml
+++ b/datastructure/predecessor_problem/info.toml
@@ -40,12 +40,10 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/632"
 
 [[solutions]]
     name = "fenwick.cpp"
-    
     allow_tle = true
 
 [[solutions]]
     name = "set.cpp"
-    
     allow_tle = true
 
 [params]

--- a/datastructure/queue_operate_all_composite/info.toml
+++ b/datastructure/queue_operate_all_composite/info.toml
@@ -26,4 +26,4 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/208"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = true
+    expect = "TLE"

--- a/datastructure/range_affine_point_get/info.toml
+++ b/datastructure/range_affine_point_get/info.toml
@@ -20,7 +20,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/778"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = true
+    expect = "RE"
 
 [params]
     N_AND_Q_MAX = 500_000

--- a/datastructure/range_affine_range_sum/info.toml
+++ b/datastructure/range_affine_range_sum/info.toml
@@ -20,7 +20,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/233"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = true
+    expect = "RE"
 
 [params]
     N_AND_Q_MAX = 500_000

--- a/datastructure/range_chmin_chmax_add_range_sum/info.toml
+++ b/datastructure/range_chmin_chmax_add_range_sum/info.toml
@@ -31,7 +31,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/243"
     name = "correct_with_assert.cpp"
 [[solutions]]
     name = "naive.cpp"
-    wrong = true
+    expect = "RE"
 
 [params]
     N_AND_Q_MAX = 200_000

--- a/datastructure/range_kth_smallest/info.toml
+++ b/datastructure/range_kth_smallest/info.toml
@@ -32,7 +32,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/310"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = true
+    expect = "TLE"
 
 [params]
     N_MIN = 1

--- a/datastructure/range_reverse_range_sum/info.toml
+++ b/datastructure/range_reverse_range_sum/info.toml
@@ -26,7 +26,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/538"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = false
+    
     allow_tle = true
 
 [params]

--- a/datastructure/range_reverse_range_sum/info.toml
+++ b/datastructure/range_reverse_range_sum/info.toml
@@ -26,7 +26,6 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/538"
 
 [[solutions]]
     name = "naive.cpp"
-    
     allow_tle = true
 
 [params]

--- a/datastructure/rectangle_sum/info.toml
+++ b/datastructure/rectangle_sum/info.toml
@@ -23,4 +23,4 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/118"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = true
+    expect = "RE"

--- a/datastructure/segment_add_get_min/info.toml
+++ b/datastructure/segment_add_get_min/info.toml
@@ -20,7 +20,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/211"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = true
+    expect = "RE"
 
 [params]
     N_AND_Q_MIN = 1

--- a/datastructure/static_range_count_distinct/info.toml
+++ b/datastructure/static_range_count_distinct/info.toml
@@ -20,7 +20,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/770"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = false
+    
     allow_tle = true
 
 [params]

--- a/datastructure/static_range_inversions_query/info.toml
+++ b/datastructure/static_range_inversions_query/info.toml
@@ -20,7 +20,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/563"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = true
+    expect = "RE"
 
 [params]
     N_MIN = 1

--- a/datastructure/static_range_mode_query/info.toml
+++ b/datastructure/static_range_mode_query/info.toml
@@ -20,7 +20,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/959"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = false
+    
     allow_tle = true
 
 [params]

--- a/datastructure/static_range_sum/info.toml
+++ b/datastructure/static_range_sum/info.toml
@@ -14,7 +14,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/398"
 
 [[solutions]]
     name = "wa.cpp"
-    wrong = true
+    expect = "WA"
 
 [params]
     MAX_N = 500_000

--- a/datastructure/static_rectangle_add_rectangle_sum/info.toml
+++ b/datastructure/static_rectangle_add_rectangle_sum/info.toml
@@ -25,12 +25,10 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/771"
 
 [[solutions]]
     name = "tle_1.cpp"
-    
     allow_tle = true
 
 [[solutions]]
     name = "tle_2.cpp"
-    
     allow_tle = true
 
 

--- a/datastructure/static_rectangle_add_rectangle_sum/info.toml
+++ b/datastructure/static_rectangle_add_rectangle_sum/info.toml
@@ -25,12 +25,12 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/771"
 
 [[solutions]]
     name = "tle_1.cpp"
-    wrong = false
+    
     allow_tle = true
 
 [[solutions]]
     name = "tle_2.cpp"
-    wrong = false
+    
     allow_tle = true
 
 

--- a/datastructure/vertex_add_path_sum/info.toml
+++ b/datastructure/vertex_add_path_sum/info.toml
@@ -26,7 +26,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/125"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = true
+    expect = "RE"
 
 [params]
     N_AND_Q_MAX = 500_000

--- a/datastructure/vertex_add_subtree_sum/info.toml
+++ b/datastructure/vertex_add_subtree_sum/info.toml
@@ -20,4 +20,4 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/167"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = true
+    expect = "RE"

--- a/datastructure/vertex_set_path_composite/info.toml
+++ b/datastructure/vertex_set_path_composite/info.toml
@@ -31,7 +31,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/190"
     
 [[solutions]]
     name = "naive.cpp"
-    wrong = true
+    expect = "RE"
 
 [params]
     N_AND_Q_MAX = 200_000

--- a/generate.py
+++ b/generate.py
@@ -396,7 +396,7 @@ class Problem:
         _tmpdir = TemporaryDirectory()
         tmpdir = _tmpdir.name
         checker = self.checker
-        results = set()
+        results: set[str] = set()
 
         logger.info('Start {}'.format(src.name))
 
@@ -436,23 +436,24 @@ class Problem:
                                '{} : {}'.format(case, checker_output.decode('utf-8')))
 
         _tmpdir.cleanup()
-        allow_status = set()
+        expect_status: str = config.get('expect', '')  # type: ignore
+        allow_status: set[str] = set()
+        if expect_status != "":
+            allow_status.add(expect_status)
         allow_status.add('AC')
-        if config.get('wrong', False):
-            allow_status.update(['WA', 'RE', 'TLE'])
-        if config.get('allow_tle', False):
-            allow_status.add('TLE')
+        if config.get('allow_wa', False):
+            allow_status.add('WA')
         if config.get('allow_re', False):
             allow_status.add('RE')
+        if config.get('allow_tle', False):
+            allow_status.add('TLE')
 
         if len(results - allow_status) != 0:
             logger.error('unexpected status was appeared: {} (allowed {})'.format(
                 results, allow_status))
-
-        if config.get('wrong', False):
-            if results == {'AC'}:
-                logger.error('wrong solution got accept: {}'.format(src))
-                exit(1)
+        if expect_status != '' and expect_status not in results:
+            logger.error('expected status {} was not appeared: {}'.format(
+                expect_status, results))
 
     def calc_hashes(self) -> MutableMapping[str, str]:
         hashes: MutableMapping[str, str] = dict()

--- a/geo/sort_points_by_argument/info.toml
+++ b/geo/sort_points_by_argument/info.toml
@@ -32,7 +32,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/248"
 
 [[solutions]]
     name = "wa.cpp"
-    wrong = true
+    expect = "WA"
 
 
 [params]

--- a/graph/assignment/info.toml
+++ b/graph/assignment/info.toml
@@ -24,7 +24,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/38"
 
 [[solutions]]
     name = 'invalid.cpp'
-    wrong = true
+    expect = "WA"
 
 [params]
     N_MIN = 1

--- a/graph/cartesian_tree/info.toml
+++ b/graph/cartesian_tree/info.toml
@@ -26,7 +26,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/554"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = true
+    expect = "TLE"
 
 [params]
     N_MIN = 1

--- a/graph/chordal_graph_recognition/info.toml
+++ b/graph/chordal_graph_recognition/info.toml
@@ -40,16 +40,16 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/591"
     number = 5
 [[solutions]]
     name = "bfs.cpp"
-    wrong = true
+    expect = "RE"
 [[solutions]]
     name = "dfs.cpp"
-    wrong = true
+    expect = "RE"
 [[solutions]]
     name = "mcs_wa1.cpp"
-    wrong = true
+    expect = "WA"
 [[solutions]]
     name = "mcs_wa2.cpp"
-    wrong = true
+    expect = "WA"
 
 [params]
     N_MIN = 1

--- a/graph/common_interval_decomposition_tree/info.toml
+++ b/graph/common_interval_decomposition_tree/info.toml
@@ -35,13 +35,14 @@ forum = 'https://github.com/yosupo06/library-checker-problems/issues/744'
 
 [[solutions]]
 	name = "other_correct.cpp"
-	wrong = false
+	
 [[solutions]]
 	name = "WA1.cpp"
-	wrong = true
+	expect = "WA"
 [[solutions]]
 	name = "WA2.cpp"
-	wrong = true
+	expect = "WA"
+
 [params]
     P_MIN = 0
     N_MIN = 1

--- a/graph/cycle_detection/info.toml
+++ b/graph/cycle_detection/info.toml
@@ -23,7 +23,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/534"
 
 [[solutions]]
 	name = 'source_zero.cpp'
-	wrong = true
+	expect = "TLE"
 
 [params]
 	N_MIN = 2

--- a/graph/enumerate_cliques/info.toml
+++ b/graph/enumerate_cliques/info.toml
@@ -32,7 +32,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/820"
 
 [[solutions]]
 	name = 'naive.cpp'
-	wrong = true
+	expect = "TLE"
 
 [params]
 	N_MIN = 1

--- a/graph/enumerate_triangles/info.toml
+++ b/graph/enumerate_triangles/info.toml
@@ -29,13 +29,12 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/442"
 
 [[solutions]]
 	name = 'naive.cpp'
-	wrong = true
+	expect = "WA"
 [[solutions]]
 	name = 'correct_slow.cpp'
-	wrong = false
 [[solutions]]
 	name = "deg_2.cpp"
-	wrong = true
+	expect = "TLE"
 
 [params]
 	N_MIN = 1

--- a/graph/jump_on_tree/info.toml
+++ b/graph/jump_on_tree/info.toml
@@ -33,11 +33,11 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/809"
 
 [[solutions]]
   name = "tle.cpp"
-  wrong = true
+  expect = "TLE"
 
 [[solutions]]
   name = "doubling_correct.cpp"
-  wrong = false
+  
 
 [params]
     N_MIN = 2

--- a/graph/k_shortest_walk/info.toml
+++ b/graph/k_shortest_walk/info.toml
@@ -44,13 +44,13 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/509"
 	
 [[solutions]]
 	name = "wa1.cpp"
-	wrong = true
+	expect = "WA"
 [[solutions]]
 	name = "wa2.cpp"
-	wrong = true
+	expect = "WA"
 [[solutions]]
 	name = "wa3.cpp"
-	wrong = true
+	expect = "WA"
 
 [params]
 	N_AND_M_MIN = 1

--- a/graph/lca/info.toml
+++ b/graph/lca/info.toml
@@ -32,7 +32,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/35"
 
 [[solutions]]
   name = "tle.cpp"
-  wrong = true
+  expect = "TLE"
 
 [params]
     N_MIN = 2

--- a/graph/manhattanmst/info.toml
+++ b/graph/manhattanmst/info.toml
@@ -23,4 +23,4 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/180"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = true
+    expect = "RE"

--- a/graph/rooted_tree_isomorphism_classification/info.toml
+++ b/graph/rooted_tree_isomorphism_classification/info.toml
@@ -33,7 +33,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/796"
 [[solutions]]
     name = "linear-time.cpp"
     allow_tle = false
-    wrong = false
+    
 
 [params]
     N_MIN = 1

--- a/graph/scc/info.toml
+++ b/graph/scc/info.toml
@@ -17,4 +17,4 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/36"
 
 [[solutions]]
     name = 'reverse_order.cpp'    
-    wrong = true
+    expect = "WA"

--- a/graph/shortest_path/info.toml
+++ b/graph/shortest_path/info.toml
@@ -50,22 +50,22 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/173"
 
 [[solutions]]
 	name = 'wrong_dijkstra_0.cpp'
-	wrong = true
+	expect = "TLE"
 [[solutions]]
 	name = 'wrong_dijkstra_1.cpp'
-	wrong = true
+	expect = "TLE"
 [[solutions]]
 	name = 'wrong_dijkstra_2.cpp'
-	wrong = true
+	expect = "TLE"
 [[solutions]]
 	name = 'wrong_dijkstra_3.cpp'
-	wrong = true
+	expect = "TLE"
 [[solutions]]
 	name = 'spfa_slf.cpp'
-	wrong = true
+	expect = "TLE"
 [[solutions]]
 	name = 'spfa_lll.cpp'
-	wrong = true
+	expect = "TLE"
 
 [params]
 	N_MIN = 2

--- a/graph/three_edge_connected_components/info.toml
+++ b/graph/three_edge_connected_components/info.toml
@@ -26,7 +26,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/360"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = true
+    expect = "RE"
 
 [params]
     N_MIN = 1

--- a/graph/tree_path_composite_sum/info.toml
+++ b/graph/tree_path_composite_sum/info.toml
@@ -17,7 +17,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/861"
     
 [[solutions]]
     name = "naive.cpp"
-    wrong = true
+    expect = "WA"
 
 [params]
     N_MIN = 1

--- a/graph/two_edge_connected_components/info.toml
+++ b/graph/two_edge_connected_components/info.toml
@@ -26,7 +26,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/366"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = true
+    expect = "RE"
 
 [params]
     N_MIN = 1

--- a/graph/vertex_add_range_contour_sum_on_tree/info.toml
+++ b/graph/vertex_add_range_contour_sum_on_tree/info.toml
@@ -60,12 +60,12 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/816"
 [[solutions]]
     name = "correct_invertible.cpp"
     allow_tle = false
-    wrong = false
+    
 
 [[solutions]]
     name = "tle.cpp"
     allow_tle = true
-    wrong = false
+    
 
 [params]
     N_MIN = 1

--- a/graph/vertex_get_range_contour_add_on_tree/info.toml
+++ b/graph/vertex_get_range_contour_add_on_tree/info.toml
@@ -60,12 +60,12 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/831"
 [[solutions]]
     name = "correct_invertible.cpp"
     allow_tle = false
-    wrong = false
+    
 
 [[solutions]]
     name = "tle.cpp"
     allow_tle = true
-    wrong = false
+    
 
 [params]
     N_MIN = 1

--- a/math/binomial_coefficient/info.toml
+++ b/math/binomial_coefficient/info.toml
@@ -41,7 +41,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/593"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = true
+    expect = "RE"
 
 [params]
     T_MAX = 200_000

--- a/math/bitwise_and_convolution/info.toml
+++ b/math/bitwise_and_convolution/info.toml
@@ -20,7 +20,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/619"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = true
+    expect = "TLE"
 
 [params]
     N_MAX = 20

--- a/math/bitwise_xor_convolution/info.toml
+++ b/math/bitwise_xor_convolution/info.toml
@@ -20,7 +20,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/622"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = true
+    expect = "TLE"
 
 [params]
     N_MAX = 20

--- a/math/characteristic_polynomial/info.toml
+++ b/math/characteristic_polynomial/info.toml
@@ -22,7 +22,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/665"
     number = 2
 [[solutions]]
     name = "n_4.cpp"
-    wrong = true
+    expect = "RE"
 [params]
     N_MAX = 500
     MOD = 998244353

--- a/math/composition_of_formal_power_series/info.toml
+++ b/math/composition_of_formal_power_series/info.toml
@@ -25,7 +25,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/569"
     allow_tle = true
 [[solutions]]
     name = "wa.cpp"
-    wrong = true
+    expect = "WA"
 [params]
     N_MAX = 8_000
     N_SMALL_MAX = 10

--- a/math/composition_of_formal_power_series/info.toml
+++ b/math/composition_of_formal_power_series/info.toml
@@ -25,7 +25,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/569"
     allow_tle = true
 [[solutions]]
     name = "wa.cpp"
-    expect = "WA"
+    expect = "RE"
 [params]
     N_MAX = 8_000
     N_SMALL_MAX = 10

--- a/math/composition_of_formal_power_series_large/info.toml
+++ b/math/composition_of_formal_power_series_large/info.toml
@@ -23,7 +23,8 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/1112"
 [[tests]]
     name = "hack2.cpp"
     number = 3
-[[solutions]]
+
+[solutions]]
     name = "small_correct.cpp"
     allow_re = true
 [[solutions]]
@@ -31,8 +32,8 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/1112"
     allow_re = true
 [[solutions]]
     name = "wa.cpp"
-    wrong = true
-    allow_tle = true
+    expect = "WA"
+
 [params]
     N_MAX = 131_072
     N_MID_MAX = 8_000

--- a/math/composition_of_formal_power_series_large/info.toml
+++ b/math/composition_of_formal_power_series_large/info.toml
@@ -24,7 +24,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/1112"
     name = "hack2.cpp"
     number = 3
 
-[solutions]]
+[[solutions]]
     name = "small_correct.cpp"
     allow_re = true
 [[solutions]]

--- a/math/compositional_inverse_of_formal_power_series_large/info.toml
+++ b/math/compositional_inverse_of_formal_power_series_large/info.toml
@@ -26,7 +26,6 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/1112"
 
 [[solutions]]
     name = "small_correct.cpp"
-    
     allow_re = true
 
 [params]

--- a/math/compositional_inverse_of_formal_power_series_large/info.toml
+++ b/math/compositional_inverse_of_formal_power_series_large/info.toml
@@ -26,7 +26,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/1112"
 
 [[solutions]]
     name = "small_correct.cpp"
-    wrong = false
+    
     allow_re = true
 
 [params]

--- a/math/consecutive_terms_of_linear_recurrent_sequence/info.toml
+++ b/math/consecutive_terms_of_linear_recurrent_sequence/info.toml
@@ -36,7 +36,6 @@ forum = 'https://github.com/yosupo06/library-checker-problems/issues/1007'
 
 [[solutions]]
     name = "correct_doubling.cpp"
-    
     allow_tle = true
 
 [params]

--- a/math/consecutive_terms_of_linear_recurrent_sequence/info.toml
+++ b/math/consecutive_terms_of_linear_recurrent_sequence/info.toml
@@ -36,7 +36,7 @@ forum = 'https://github.com/yosupo06/library-checker-problems/issues/1007'
 
 [[solutions]]
     name = "correct_doubling.cpp"
-    wrong = false
+    
     allow_tle = true
 
 [params]

--- a/math/convolution_mod/info.toml
+++ b/math/convolution_mod/info.toml
@@ -41,7 +41,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/42"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = true
+    expect = "RE"
 [[solutions]]
     name = "ac_func.cpp"
     function = true

--- a/math/convolution_mod_1000000007/info.toml
+++ b/math/convolution_mod_1000000007/info.toml
@@ -38,7 +38,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/145"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = true
+    expect = "RE"
 
 [params]
     N_AND_M_MAX = 524288

--- a/math/convolution_mod_2_64/info.toml
+++ b/math/convolution_mod_2_64/info.toml
@@ -55,7 +55,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/664"
     name = "radix3.cpp"
 [[solutions]]
     name = "naive.cpp"
-    wrong = true
+    expect = "RE"
 
 [params]
     N_AND_M_MAX = 524288

--- a/math/convolution_mod_large/info.toml
+++ b/math/convolution_mod_large/info.toml
@@ -41,7 +41,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/720"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = true
+    expect = "RE"
 
 [params]
     N_AND_M_MAX = 16777216

--- a/math/enumerate_primes/info.toml
+++ b/math/enumerate_primes/info.toml
@@ -29,7 +29,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/158"
     allow_tle = true
 [[solutions]]
     name = "linear.cpp"
-    wrong = true
+    expect = "RE"
 
 [params]
     N_MIN = 1

--- a/math/exp_of_formal_power_series_sparse/info.toml
+++ b/math/exp_of_formal_power_series_sparse/info.toml
@@ -23,7 +23,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/767"
 
 [[solutions]]
     name = "dense_correct.cpp"
-    wrong = false
+    
 
 [params]
     N_MIN = 1

--- a/math/exp_of_set_power_series/info.toml
+++ b/math/exp_of_set_power_series/info.toml
@@ -23,7 +23,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/974"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = false
+    
     allow_tle = true
 
 [params]

--- a/math/exp_of_set_power_series/info.toml
+++ b/math/exp_of_set_power_series/info.toml
@@ -23,7 +23,6 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/974"
 
 [[solutions]]
     name = "naive.cpp"
-    
     allow_tle = true
 
 [params]

--- a/math/factorial/info.toml
+++ b/math/factorial/info.toml
@@ -17,7 +17,6 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/128"
 
 [[solutions]]
     name = "naive.cpp"
-    
     allow_tle = true
 
 

--- a/math/factorial/info.toml
+++ b/math/factorial/info.toml
@@ -17,7 +17,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/128"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = false
+    
     allow_tle = true
 
 

--- a/math/factorize/info.toml
+++ b/math/factorize/info.toml
@@ -53,10 +53,10 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/41"
 
 [[solutions]]
     name = "fixed_RNG.cpp"
-    wrong = true
+    expect = "TLE"
 [[solutions]]
     name = "rho_with_difference_of_square.cpp"
-    wrong = false
+    
 
 [params]
     MAX_Q = 100

--- a/math/gcd_convolution/info.toml
+++ b/math/gcd_convolution/info.toml
@@ -26,7 +26,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/749"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = true
+    expect = "RE"
 
 [params]
     N_MAX = 1000000

--- a/math/gcd_of_gaussian_integers/info.toml
+++ b/math/gcd_of_gaussian_integers/info.toml
@@ -24,7 +24,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/958"
 
 [[solutions]]
     name = "random_correct.cpp"
-    wrong = false
+    
     
 [params]
     T_MAX = 100000

--- a/math/hafnian_of_matrix/info.toml
+++ b/math/hafnian_of_matrix/info.toml
@@ -20,10 +20,10 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/467"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = true
+    expect = "RE"
 [[solutions]]
     name = "bitdp.cpp"
-    wrong = true
+    expect = "RE"
 
 [params]
     N_MIN = 2

--- a/math/intersection_of_f2_vector_spaces/info.toml
+++ b/math/intersection_of_f2_vector_spaces/info.toml
@@ -33,7 +33,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/923"
 
 [[solutions]]
     name = "wa_size_only.cpp"
-    wrong = true
+    expect = "WA"
 
 [params]
     T_MAX = 100_000

--- a/math/inv_of_formal_power_series_sparse/info.toml
+++ b/math/inv_of_formal_power_series_sparse/info.toml
@@ -23,7 +23,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/767"
 
 [[solutions]]
     name = "dense_correct.cpp"
-    wrong = false
+    
 
 [params]
     N_MIN = 1

--- a/math/kth_term_of_linearly_recurrent_sequence/info.toml
+++ b/math/kth_term_of_linearly_recurrent_sequence/info.toml
@@ -24,7 +24,7 @@ forum = 'https://github.com/yosupo06/library-checker-problems/issues/601'
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = true
+    expect = "RE"
 
 [params]
   D_MAX = 100_000

--- a/math/lcm_convolution/info.toml
+++ b/math/lcm_convolution/info.toml
@@ -26,7 +26,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/749"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = true
+    expect = "RE"
 
 [params]
     N_MAX = 1000000

--- a/math/log_of_formal_power_series_sparse/info.toml
+++ b/math/log_of_formal_power_series_sparse/info.toml
@@ -23,7 +23,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/767"
 
 [[solutions]]
     name = "dense_correct.cpp"
-    wrong = false
+    
 
 [params]
     N_MIN = 1

--- a/math/many_factorials/info.toml
+++ b/math/many_factorials/info.toml
@@ -20,22 +20,18 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/1058"
 
 [[solutions]]
     name = "correct_log_time_multieval_faster.cpp"
-    
     allow_tle = false
 
 [[solutions]]
     name = "correct_log_time_multieval.cpp"
-    
     allow_tle = false
 
 [[solutions]]
     name = "sqrt.cpp"
-    
     allow_tle = true
 
 [[solutions]]
     name = "naive.cpp"
-    
     allow_tle = true
 
 [params]

--- a/math/many_factorials/info.toml
+++ b/math/many_factorials/info.toml
@@ -20,22 +20,22 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/1058"
 
 [[solutions]]
     name = "correct_log_time_multieval_faster.cpp"
-    wrong = false
+    
     allow_tle = false
 
 [[solutions]]
     name = "correct_log_time_multieval.cpp"
-    wrong = false
+    
     allow_tle = false
 
 [[solutions]]
     name = "sqrt.cpp"
-    wrong = false
+    
     allow_tle = true
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = false
+    
     allow_tle = true
 
 [params]

--- a/math/matrix_det_mod_2/info.toml
+++ b/math/matrix_det_mod_2/info.toml
@@ -26,7 +26,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/896"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = false
+    
     allow_re = true
 
 [params]

--- a/math/matrix_det_mod_2/info.toml
+++ b/math/matrix_det_mod_2/info.toml
@@ -26,7 +26,6 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/896"
 
 [[solutions]]
     name = "naive.cpp"
-    
     allow_re = true
 
 [params]

--- a/math/matrix_product_mod_2/info.toml
+++ b/math/matrix_product_mod_2/info.toml
@@ -20,7 +20,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/896"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = false
+    
     allow_tle = true
 
 [params]

--- a/math/matrix_product_mod_2/info.toml
+++ b/math/matrix_product_mod_2/info.toml
@@ -20,7 +20,6 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/896"
 
 [[solutions]]
     name = "naive.cpp"
-    
     allow_tle = true
 
 [params]

--- a/math/min_of_mod_of_linear/info.toml
+++ b/math/min_of_mod_of_linear/info.toml
@@ -18,7 +18,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/813"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = false
+    
     allow_tle = true
 
 [params]

--- a/math/min_of_mod_of_linear/info.toml
+++ b/math/min_of_mod_of_linear/info.toml
@@ -18,7 +18,6 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/813"
 
 [[solutions]]
     name = "naive.cpp"
-    
     allow_tle = true
 
 [params]

--- a/math/min_plus_convolution_convex_arbitrary/info.toml
+++ b/math/min_plus_convolution_convex_arbitrary/info.toml
@@ -48,7 +48,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/727"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = false
+    
     allow_tle = true
 
 [params]

--- a/math/min_plus_convolution_convex_arbitrary/info.toml
+++ b/math/min_plus_convolution_convex_arbitrary/info.toml
@@ -48,7 +48,6 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/727"
 
 [[solutions]]
     name = "naive.cpp"
-    
     allow_tle = true
 
 [params]

--- a/math/min_plus_convolution_convex_convex/info.toml
+++ b/math/min_plus_convolution_convex_convex/info.toml
@@ -36,7 +36,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/727"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = false
+    
     allow_tle = true
 
 [params]

--- a/math/min_plus_convolution_convex_convex/info.toml
+++ b/math/min_plus_convolution_convex_convex/info.toml
@@ -36,7 +36,6 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/727"
 
 [[solutions]]
     name = "naive.cpp"
-    
     allow_tle = true
 
 [params]

--- a/math/mul_mod2n_convolution/info.toml
+++ b/math/mul_mod2n_convolution/info.toml
@@ -23,7 +23,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/728"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = true
+    expect = "TLE"
 
 [params]
     N_MAX = 20

--- a/math/multipoint_evaluation_on_geometric_sequence/info.toml
+++ b/math/multipoint_evaluation_on_geometric_sequence/info.toml
@@ -26,7 +26,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/906"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = false
+    
     allow_tle = true
 
 [params]

--- a/math/multipoint_evaluation_on_geometric_sequence/info.toml
+++ b/math/multipoint_evaluation_on_geometric_sequence/info.toml
@@ -26,7 +26,6 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/906"
 
 [[solutions]]
     name = "naive.cpp"
-    
     allow_tle = true
 
 [params]

--- a/math/multivariate_convolution/info.toml
+++ b/math/multivariate_convolution/info.toml
@@ -29,7 +29,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/633"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = true
+    expect = "TLE"
 
 [params]
     K_MAX = 18

--- a/math/multivariate_convolution_cyclic/info.toml
+++ b/math/multivariate_convolution_cyclic/info.toml
@@ -29,7 +29,6 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/746"
 
 [[solutions]]
     name = "naive.cpp"
-    
     allow_tle = true
 
 [params]

--- a/math/multivariate_convolution_cyclic/info.toml
+++ b/math/multivariate_convolution_cyclic/info.toml
@@ -29,7 +29,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/746"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = false
+    
     allow_tle = true
 
 [params]

--- a/math/polynomial_composite_set_power_series/info.toml
+++ b/math/polynomial_composite_set_power_series/info.toml
@@ -20,7 +20,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/944"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = false
+    
     allow_tle = true
 
 [params]

--- a/math/polynomial_interpolation_on_geometric_sequence/info.toml
+++ b/math/polynomial_interpolation_on_geometric_sequence/info.toml
@@ -29,7 +29,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/965"
 
 [[solutions]]
     name = "arbitrary_interpolation.cpp"
-    wrong = false
+    
     allow_tle = true
 
 [params]

--- a/math/polynomial_interpolation_on_geometric_sequence/info.toml
+++ b/math/polynomial_interpolation_on_geometric_sequence/info.toml
@@ -29,7 +29,6 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/965"
 
 [[solutions]]
     name = "arbitrary_interpolation.cpp"
-    
     allow_tle = true
 
 [params]

--- a/math/polynomial_root_finding/info.toml
+++ b/math/polynomial_root_finding/info.toml
@@ -31,7 +31,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/924"
 [[solutions]]
     name = "print_sorted.cpp"
     number = 1
-    wrong = false
+    
 
 [params]
     N_MAX = 4000

--- a/math/pow_of_formal_power_series/info.toml
+++ b/math/pow_of_formal_power_series/info.toml
@@ -41,7 +41,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/386"
 
 [[solutions]]
     name = "wa_overflow.cpp"
-    wrong = true
+    expect = "WA"
     
 [params]
     N_MAX = 500000

--- a/math/pow_of_formal_power_series_sparse/info.toml
+++ b/math/pow_of_formal_power_series_sparse/info.toml
@@ -33,11 +33,11 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/767"
 
 [[solutions]]
     name = "dense_correct.cpp"
-    wrong = false
+    
     allow_tle = true
 [[solutions]]
     name = "wa_overflow.cpp"
-    wrong = true
+    expect = "TLE"
     allow_tle = true
 
 [params]

--- a/math/pow_of_formal_power_series_sparse/info.toml
+++ b/math/pow_of_formal_power_series_sparse/info.toml
@@ -33,7 +33,6 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/767"
 
 [[solutions]]
     name = "dense_correct.cpp"
-    
     allow_tle = true
 [[solutions]]
     name = "wa_overflow.cpp"

--- a/math/power_projection_of_set_power_series/info.toml
+++ b/math/power_projection_of_set_power_series/info.toml
@@ -23,7 +23,6 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/975"
 
 [[solutions]]
     name = "naive.cpp"
-    
     allow_tle = true
 
 [params]

--- a/math/power_projection_of_set_power_series/info.toml
+++ b/math/power_projection_of_set_power_series/info.toml
@@ -23,7 +23,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/975"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = false
+    
     allow_tle = true
 
 [params]

--- a/math/rational_approximation/info.toml
+++ b/math/rational_approximation/info.toml
@@ -39,10 +39,10 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/960"
 [[solutions]]
     name = "no_binary_search.cpp"
     allow_tle = true
-    wrong = false
+    
 [[solutions]]
     name = "use_floating_point_number.cpp"
-    wrong = true
+    expect = "WA"
 
 [params]
     MAX_T = 100_000

--- a/math/sqrt_of_formal_power_series_sparse/info.toml
+++ b/math/sqrt_of_formal_power_series_sparse/info.toml
@@ -24,7 +24,6 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/767"
 
 [[solutions]]
     name = "dense_correct.cpp"
-    
     allow_tle = true
 
 [params]

--- a/math/sqrt_of_formal_power_series_sparse/info.toml
+++ b/math/sqrt_of_formal_power_series_sparse/info.toml
@@ -24,7 +24,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/767"
 
 [[solutions]]
     name = "dense_correct.cpp"
-    wrong = false
+    
     allow_tle = true
 
 [params]

--- a/math/stirling_number_of_the_first_kind/info.toml
+++ b/math/stirling_number_of_the_first_kind/info.toml
@@ -35,7 +35,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/336"
 
 [[solutions]]
     name = "slow.cpp"
-    wrong = false
+    
 
 [params]
     MOD = 998244353

--- a/math/stirling_number_of_the_first_kind_small_p_large_n/info.toml
+++ b/math/stirling_number_of_the_first_kind_small_p_large_n/info.toml
@@ -18,7 +18,6 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/817"
 
 [[solutions]]
     name = "naive.cpp"
-    
     allow_tle = true
 
 [params]

--- a/math/stirling_number_of_the_first_kind_small_p_large_n/info.toml
+++ b/math/stirling_number_of_the_first_kind_small_p_large_n/info.toml
@@ -18,7 +18,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/817"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = false
+    
     allow_tle = true
 
 [params]

--- a/math/stirling_number_of_the_second_kind_small_p_large_n/info.toml
+++ b/math/stirling_number_of_the_second_kind_small_p_large_n/info.toml
@@ -18,7 +18,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/817"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = false
+    
     allow_tle = true
 
 [params]

--- a/math/subset_convolution/info.toml
+++ b/math/subset_convolution/info.toml
@@ -20,7 +20,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/297"
 
 [[solutions]]
     name = "naive.cpp"
-    wrong = true
+    expect = "RE"
 
 [params]
     N_MAX = 20

--- a/math/sum_of_exponential_times_polynomial/info.toml
+++ b/math/sum_of_exponential_times_polynomial/info.toml
@@ -17,10 +17,10 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/98"
 
 [[solutions]]
     name = "correct2.cpp"
-    wrong = false
+    
 [[solutions]]
     name = "brute.cpp"
-    wrong = true
+    expect = "TLE"
 
 [params]
     MOD = 998244353

--- a/math/sum_of_exponential_times_polynomial_limit/info.toml
+++ b/math/sum_of_exponential_times_polynomial_limit/info.toml
@@ -14,7 +14,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/99"
 
 [[solutions]]
     name = "eulerian_table.cpp"
-    wrong = true
+    expect = "RE"
 
 [params]
     MOD = 998244353

--- a/sample/aplusb/info.toml
+++ b/sample/aplusb/info.toml
@@ -11,7 +11,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/32"
 
 [[solutions]]
     name = "wa.cpp"
-    wrong = true
+    expect = "WA"
 [[solutions]]
     name = "ac_func.cpp"
     function = true

--- a/string/enumerate_palindromes/info.toml
+++ b/string/enumerate_palindromes/info.toml
@@ -24,7 +24,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/574"
 
 [[solutions]]
     name ="naive.cpp"
-    wrong = true
+    expect = "TLE"
 
 [params]
     N_MAX = 500000

--- a/string/wildcard_pattern_matching/info.toml
+++ b/string/wildcard_pattern_matching/info.toml
@@ -31,7 +31,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/931"
 
 [[solutions]]
     name = "mod998244353.cpp"
-    wrong = true
+    expect = "WA"
 
 [params]
     S_LEN_MAX = 524288


### PR DESCRIPTION
ref #823

The usage of `wrong = True` of info.toml is unclear. This PR would

- remove `wrong = True`
- introduce new config, `expect = 'XX'`

If we set `expect = 'WA'` for a solution, this solution have to got `'WA'` for at least 1 case.

Formally,

Let

- $S$ be the set of the status of the solution of each testcases.
- $e$ be the status that is specified by `expect` config.
- $A$ be the set of status that is specified by `actual_re, actual_tle, actual_wa` configs.

The following conditions have to be satisfied:
- when the solution have an `expect` config
  - $e \in S$
  - $S \subseteq (\mathrm{'AC'} \cup A \cup {e})$
- does not have an `expect` config
  - $S \subseteq (\mathrm{'AC'} \cup A)$
