### PR TITLE
Ignore *.pyc and venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,12 @@
 in/
 out/
 params.h
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Environments
+.venv/
+venv/


### PR DESCRIPTION
venv は #776 と同じ変更です。Python 開発において venv で環境を隔離したいことは多々あるので gitignore に入れておきたいです。

pycache は実行時にキャッシュが生成されるのでそれを無視したいというものです。