### PR TITLE
Redundant $ in English statement

### DIFF
--- a/graph/st_numbering/task.md
+++ b/graph/st_numbering/task.md
@@ -9,7 +9,7 @@ You are also given two vertices $s$ and $t$ of $G$.
 
 Determine if there exists a permutation $p = (p _ 0,\ldots,p _ {N - 1})$ of the vertices satisfying the following condition, and if so, find such a permutation.
 
-- Orient each edge of $G$ from $u _ i$ to $v _ i$ if $p _ {u _ i} < p _ {v _ i}$, or from $v _ i$ to $u _ i$ if $p _ {v _ i} < $p _ {u _ i}$. Then, for any vertex $v$, there exists a path from $s$ to $t$ that passes through $v$.
+- Orient each edge of $G$ from $u _ i$ to $v _ i$ if $p _ {u _ i} < p _ {v _ i}$, or from $v _ i$ to $u _ i$ if $p _ {v _ i} < p _ {u _ i}$. Then, for any vertex $v$, there exists a path from $s$ to $t$ that passes through $v$.
 
 @{lang.ja}
 この問題は $T$ ケースあります．


### PR DESCRIPTION
Fixes misrendering:

![image](https://github.com/yosupo06/library-checker-problems/assets/14077831/0079f182-dbe8-4be3-9cd1-224488a706d4)

becomes

![image](https://github.com/yosupo06/library-checker-problems/assets/14077831/5ec604cf-764a-4c73-b8f0-99c457449d20)
