### PR TITLE
Python 3.8 以上では動かせるようにする

### DIFF
--- a/.github/workflows/util_test.yml
+++ b/.github/workflows/util_test.yml
@@ -19,6 +19,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --user -r requirements.txt
+      - name: Linter
+        uses: chartboost/ruff-action@v1
+        with:
+          args: "check --target-version py38 --select=FA102"
       - name: Run generate_test.py
         run: |
           ulimit -s unlimited

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Source code of [https://judge.yosupo.jp](https://judge.yosupo.jp). You can get t
 ## Requirements
 
 - Linux / OS X / Windows(MinGW-w64)
-- python3.6+
+- Python 3.8+
 - g++ / clang++ (Needs --std=c++17 and __int128_t)
 
 ## How to Use

--- a/generate.py
+++ b/generate.py
@@ -6,20 +6,16 @@ import platform
 from logging import basicConfig, getLogger
 from os import getenv
 from pathlib import Path
-from typing import List
 import sysconfig
 import os
 import shutil
 import hashlib
 import json
 from datetime import datetime
-from logging import getLogger
-from os import getenv
-from pathlib import Path
 from subprocess import (PIPE, STDOUT, CalledProcessError,
                         TimeoutExpired, check_call, run)
 from tempfile import TemporaryDirectory
-from typing import Any, Iterator, List, MutableMapping, Optional
+from typing import Any, Iterator, List, MutableMapping, Optional, Union
 
 from enum import Enum
 import toml
@@ -30,7 +26,7 @@ CASENAME_LEN_LIMIT = 40
 STACK_SIZE = 2 ** 28  # 256 MB
 
 
-def casename(name: str | Path, i: int) -> str:
+def casename(name: Union[str, Path], i: int) -> str:
     """(random, 1) -> random_01"""
     return Path(name).stem + '_' + str(i).zfill(2)
 
@@ -58,7 +54,7 @@ def find_problem_dir(rootdir: Path, problem_name: Path) -> Optional[Path]:
     return tomls[0].parent
 
 
-def compile(src: Path, rootdir: Path, opts: list[str] = []):
+def compile(src: Path, rootdir: Path, opts: List[str] = []):
     if src.suffix == '.cpp':
         # use clang for msys2 clang environment
         if os.name == 'nt' and sysconfig.get_platform().startswith('mingw') and sysconfig.get_platform().endswith('clang'):

--- a/generate_test.py
+++ b/generate_test.py
@@ -10,11 +10,10 @@ from shutil import copy
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from generate import Problem, param_to_str, casename
-from typing import List
 
 logger = getLogger(__name__)
 
-@unittest.skipIf(getenv('ENABLE_GENERATE_TEST') == None, "generate test take long time")
+@unittest.skipIf(getenv('ENABLE_GENERATE_TEST') is None, "generate test take long time")
 class TestGenerateAll(unittest.TestCase):
     def test_generate_all(self):
         tomls = list(filter(lambda p: not p.match('test/**/info.toml'), Path('.').glob('**/info.toml')))
@@ -237,11 +236,11 @@ class TestCacheTest(unittest.TestCase):
             in_path = Path(test_dir) / \
                 'simple_aplusb/in/random_00.in'  # type: Path
             self.assertFalse(in_path.exists())
-            proc = run(
+            run(
                 ['./generate.py', str(Path(test_dir) / 'simple_aplusb/info.toml')])
             self.assertTrue(in_path.exists())
             time = in_path.stat().st_mtime_ns
-            proc = run(
+            run(
                 ['./generate.py', str(Path(test_dir) / 'simple_aplusb/info.toml')])
             self.assertTrue(in_path.exists())
             self.assertEqual(time, in_path.stat().st_mtime_ns)
@@ -251,11 +250,11 @@ class TestCacheTest(unittest.TestCase):
             in_path = Path(test_dir) / \
                 'simple_aplusb/in/random_00.in'  # type: Path
             self.assertFalse(in_path.exists())
-            proc = run(
+            run(
                 ['./generate.py', str(Path(test_dir) / 'simple_aplusb/info.toml'), '--dev'])
             self.assertTrue(in_path.exists())
             time = in_path.stat().st_mtime_ns
-            proc = run(
+            run(
                 ['./generate.py', str(Path(test_dir) / 'simple_aplusb/info.toml'), '--dev'])
             self.assertTrue(in_path.exists())
             self.assertNotEqual(time, in_path.stat().st_mtime_ns)


### PR DESCRIPTION
Fix #1181

やはり EOL を迎えてないバージョンは生かしておいた方が良いかなあと思いました。

デグレーション防止のために Linter (ruff) を追加しています。ruff が指摘してきたので

- 重複 import
- 未使用変数

も合わせて対応しています。