### PR TITLE
Sqrt Polynomial の checker で値の範囲をチェック

### DIFF
--- a/polynomial/sqrt_of_formal_power_series/checker.cpp
+++ b/polynomial/sqrt_of_formal_power_series/checker.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 #include <cassert>
 #include "testlib.h"
+#include "params.h"
 
 using namespace std;
 using uint = unsigned int;
@@ -113,12 +114,12 @@ bool has_sqrt(vector<Mint> pol) {
 
 bool read_ans(InStream& stream, vector<Mint> expect) {
     int n = int(expect.size());
-    int first = stream.readInt();
+    int first = stream.readInt(-1, MOD - 1);
     if (first == -1) return false;    
     vector<Mint> pol(n);
     pol[0] = first;
     for (int i = 1; i < n; i++) {
-        pol[i] = stream.readInt();
+        pol[i] = stream.readInt(0, MOD - 1);
     }
 
 

--- a/polynomial/sqrt_of_formal_power_series_sparse/checker.cpp
+++ b/polynomial/sqrt_of_formal_power_series_sparse/checker.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 #include <cassert>
 #include "testlib.h"
+#include "params.h"
 
 using namespace std;
 using uint = unsigned int;
@@ -115,11 +116,11 @@ bool has_sqrt(vector<Mint> pol) {
 
 bool read_ans(InStream& stream, vector<Mint> expect) {
   int n = int(expect.size());
-  int first = stream.readInt();
+  int first = stream.readInt(-1, MOD - 1);
   if (first == -1) return false;
   vector<Mint> pol(n);
   pol[0] = first;
-  for (int i = 1; i < n; i++) { pol[i] = stream.readInt(); }
+  for (int i = 1; i < n; i++) { pol[i] = stream.readInt(0, MOD - 1); }
 
   auto pol2 = multiply(pol, pol);
 


### PR DESCRIPTION
resolve #1239

チェッカーが出力を読み込むときに値の範囲チェックをせずに modint に入力しているため、出力が変な値でも AC する可能性がありました。

`-1` 以外の場合、出力が 0 以上 MOD 未満でなければ WA にするようにしました。