### PR TITLE
chore(workflow): change ruff workflow to the official one

### DIFF
--- a/.github/workflows/util_test.yml
+++ b/.github/workflows/util_test.yml
@@ -20,7 +20,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install --user -r requirements.txt
       - name: Linter
-        uses: chartboost/ruff-action@v1
+        uses: astral-sh/ruff-action@v1
         with:
           args: "check --target-version py38 --select=FA102"
       - name: Run generate_test.py


### PR DESCRIPTION
According to [ChartBoost/ruff-action](https://github.com/ChartBoost/ruff-action), this project is no longer maintained. And it's suggested to use [astral-sh/ruff-action](https://github.com/astral-sh/ruff-action), which is officially-supported.

So let's change to the official one.