### PR TITLE
Improve Code Style

### DIFF
--- a/tree/vertex_add_path_sum/sol/correct.cpp
+++ b/tree/vertex_add_path_sum/sol/correct.cpp
@@ -72,7 +72,8 @@ template <class E> struct HLExec : HL {
     V<int> tch;
     int id = 0;
     HLExec(const VV<E>& _g, int r) : HL(_g.size()), g(_g), tch(g.size(), -1) {
-        assert(dfs_sz(r, -1) == int(g.size()));
+        int size = dfs_sz(r, -1);
+        assert(size == int(g.size()));
         dfs(r, -1);
         init_extra();
     }

--- a/tree/vertex_set_path_composite/sol/correct.cpp
+++ b/tree/vertex_set_path_composite/sol/correct.cpp
@@ -79,7 +79,8 @@ template <class E> struct HLExec : HL {
     V<int> tch;
     int id = 0;
     HLExec(const VV<E>& _g, int r) : HL(_g.size()), g(_g), tch(g.size(), -1) {
-        assert(dfs_sz(r, -1) == int(g.size()));
+        int size = dfs_sz(r, -1);
+        assert(size == int(g.size()));
         dfs(r, -1);
         init_extra();
     }


### PR DESCRIPTION
The correctness of a program shouldn't rely on side effects in an assert statement. This can lead to unexpected behavior in release builds where assertions are disabled.