### PR TITLE
add wrost case for heavy light decomposition

### DIFF
--- a/tree/vertex_set_path_composite/gen/wrost_for_heavy_light.cpp
+++ b/tree/vertex_set_path_composite/gen/wrost_for_heavy_light.cpp
@@ -1,0 +1,63 @@
+#include "../params.h"
+#include "random.h"
+
+using namespace std;
+
+int main(int, char* argv[]) {
+    long long seed = atoll(argv[1]);
+    auto gen = Random(seed);
+
+    int n = N_AND_Q_MAX;
+    int q = N_AND_Q_MAX;
+    printf("%d %d\n", n, q);
+    for (int i = 0; i < n; i++) {
+        int a = gen.uniform<int>(1, MOD - 1);
+        int b = gen.uniform<int>(0, MOD - 1);
+        printf("%d %d\n", a, b);
+    }
+
+    constexpr int LG = 14;
+    int leaf_begin = 2 << LG;
+    int leaf_mid = 3 << LG;
+    int leaf_end = 4 << LG;
+    vector<int> top(leaf_end);
+    iota(top.begin(), top.end(), 0);
+
+    vector<pair<int, int>> edge;
+    edge.reserve(n);
+    for (int i = leaf_end; i < n; ++i) {
+        int u = gen.uniform<int>(leaf_begin, leaf_end - 1) >>
+                gen.uniform<int>(1, LG);
+        edge.emplace_back(i, top[u]);
+        top[u] = i;
+    }
+    for (int i = 1; i < leaf_end; ++i) {
+        edge.emplace_back(top[i], i / 2);
+    }
+
+    vector<int> perm = gen.perm<int>(n - 1);
+    for (int& element : perm) ++element;
+    perm.insert(perm.begin(), 0);
+    for (auto [u, v] : edge) {
+        if (gen.uniform<int>(0, 1)) swap(u, v);
+        printf("%d %d\n", perm[u], perm[v]);
+    }
+
+    for (int i = 0; i < q; i++) {
+        int t = gen.uniform(0, 1);
+        printf("%d ", t);
+        if (t == 0) {
+            int p = gen.uniform(0, n - 1);
+            int c = gen.uniform<int>(1, MOD - 1);
+            int d = gen.uniform<int>(0, MOD - 1);
+            printf("%d %d %d\n", p, c, d);
+        } else {
+            int u = gen.uniform<int>(leaf_begin, leaf_mid - 1);
+            int v = gen.uniform<int>(leaf_mid, leaf_end - 1);
+            int x = gen.uniform<int>(0, MOD - 1);
+            if (gen.uniform<int>(0, 1)) swap(u, v);
+            printf("%d %d %d\n", perm[u], perm[v], x);
+        }
+    }
+    return 0;
+}

--- a/tree/vertex_set_path_composite/hash.json
+++ b/tree/vertex_set_path_composite/hash.json
@@ -34,5 +34,9 @@
   "small_03.in": "4e1ea99ea9b9a8a6910beaec90a0a473937fa5fe4addf8e6636fa28be28f07c4",
   "small_03.out": "35275ef5339007a97141bc7315cc7648764a07236df2376917bb0b1246f768a6",
   "small_04.in": "7ffbaeaa927a8c2bf8140b04d74af6c563ee11c9a6bdf22bc5a0961cda13b194",
-  "small_04.out": "941e7a2c091ec7f071fcd94fa8c224bcebebb373e849c5c1ad2dd2914b833cbd"
+  "small_04.out": "941e7a2c091ec7f071fcd94fa8c224bcebebb373e849c5c1ad2dd2914b833cbd",
+  "wrost_for_heavy_light_00.in": "673c046f7a07659bc23f2d46e50e332821ace907c68a5a74c7dfa2ac93a22e62",
+  "wrost_for_heavy_light_00.out": "ada74372d4146255bead75b0fb2478bc42a20e18246a08077f2fb5b3644585a8",
+  "wrost_for_heavy_light_01.in": "d6b38539ab7584934ea52986b7bcc79d10ff2fa1c12d12e0fc75f0abcc8c7e61",
+  "wrost_for_heavy_light_01.out": "ce9d1db0b1cb5d285bfddf75582a4f29f1d424b059a816dd3d5cd1ece43e7a40"
 }

--- a/tree/vertex_set_path_composite/info.toml
+++ b/tree/vertex_set_path_composite/info.toml
@@ -18,6 +18,10 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/190"
     number = 5
 
 [[tests]]
+    name = "wrost_for_heavy_light.cpp"
+    number = 2
+
+[[tests]]
     name = "long-path-decomposition_killer.cpp"
     number = 1
 


### PR DESCRIPTION
While this problem can be solved using segment tree and heavy-light decomposition with a time complexity of $O(n \log n^2)$, the current test cases do not account for this time complexity limitation. The new test case introduces a special binary tree that better reflects this complexity, which can increase the code execution times of the fastest 10 (deduplicated) submission by 0.5 to 1 times.