### PR TITLE
Min-Plus Convolution 3 問に C++(Function) サポートを追加

### DIFF
--- a/convolution/min_plus_convolution_concave_arbitrary/grader/grader.cpp
+++ b/convolution/min_plus_convolution_concave_arbitrary/grader/grader.cpp
@@ -1,0 +1,41 @@
+#include <chrono>
+#include <iostream>
+#include <utility>
+
+#include "fastio.h"
+#include "solve.hpp"
+
+using namespace std::chrono;
+using namespace library_checker;
+
+int main() {
+    Scanner sc = Scanner(stdin);
+    Printer pr = Printer(stdout);
+
+    int n = 0, m = 0;
+    sc.read(n, m);
+
+    std::vector<int> a(n), b(m);
+    for (int i = 0; i < n; i++) {
+        sc.read(a[i]);
+    }
+    for (int i = 0; i < m; i++) {
+        sc.read(b[i]);
+    }
+
+    steady_clock::time_point begin = steady_clock::now();
+    auto ans = solve(std::move(a), std::move(b));
+    steady_clock::time_point end = steady_clock::now();
+
+    auto elapsed_time = duration_cast<milliseconds>(end - begin);
+    std::cerr << "solve() consumes: " << elapsed_time.count() << "ms"
+              << std::endl;
+
+    for (int i = 0; i <= (n - 1) + (m - 1); i++) {
+        if (i) pr.write(' ');
+        pr.write(ans[i]);
+    }
+    pr.writeln();
+
+    return 0;
+}

--- a/convolution/min_plus_convolution_concave_arbitrary/grader/solve.hpp
+++ b/convolution/min_plus_convolution_concave_arbitrary/grader/solve.hpp
@@ -1,0 +1,3 @@
+#include <vector>
+
+std::vector<int> solve(std::vector<int> a, std::vector<int> b);

--- a/convolution/min_plus_convolution_concave_arbitrary/info.toml
+++ b/convolution/min_plus_convolution_concave_arbitrary/info.toml
@@ -50,6 +50,10 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/1252"
     name = "naive.cpp"
     allow_tle = true
 
+[[solutions]]
+    name = "ac_func.cpp"
+    function = true
+
 [params]
     N_MAX = 524288
     A_MIN = 0

--- a/convolution/min_plus_convolution_concave_arbitrary/sol/ac_func.cpp
+++ b/convolution/min_plus_convolution_concave_arbitrary/sol/ac_func.cpp
@@ -1,0 +1,106 @@
+#include <cstdio>
+#include <vector>
+#include <cassert>
+#include <limits>
+#include <functional>
+
+using namespace std;
+
+
+template <class FUNC>
+vector<int> monotone_minima(int h, int w, const FUNC& a) {
+	vector<int> j_min(h);
+
+	for (int di = 1 << 20; di > 0; di >>= 1) {
+		int di2 = 2 * di;
+		for (int i = di; i <= h; i += di2) {
+			int jL = (i - di > 0 ? j_min[i - di - 1] : 0);
+			int jR = (i + di <= h ? j_min[i + di - 1] : w - 1);
+
+			int a_min = numeric_limits<int>::max();
+			for (int j = jL; j <= jR; j++) {
+				int val = a(i - 1, j);
+				
+				if (a_min > val) {
+					a_min = val;
+					j_min[i - 1] = j;
+				}
+			}
+		}
+	}
+
+	return j_min;
+}
+
+
+vector<int> solve(vector<int> b, vector<int> a) {
+	int n = (int)a.size(), m = (int)b.size();
+	
+	// b is concave
+	for (int i = 0; i < m - 2; ++i) assert(b[i] + b[i + 2] <= 2 * b[i + 1]);
+
+	int h = n + m - 1, w = n;
+
+	vector<int> y_min(h, 0), y_max(h, w - 1);
+	for (int x = m; x <= h - 1; x++) y_min[x] = x - m + 1;
+	for (int x = 0; x <= h - m; x++) y_max[x] = x;
+
+	vector<int> x_min(w), x_max(w);
+	for (int y = 0; y < w; y++) {
+		x_min[y] = y;
+		x_max[y] = m - 1 + y;
+	}
+
+	vector<int> c(h, numeric_limits<int>::max());
+
+	function<void(int, int, int, int)> rf = [&](int x1, int x2, int y1, int y2) {
+		if (y_max[x1] >= y2 && y1 >= y_min[x2]) {
+			auto A = [&](int i, int j) {
+				return a[y2 - j] + b[(x1 + i) - (y2 - j)];
+			};
+
+			auto j_min = monotone_minima(x2 - x1 + 1, y2 - y1 + 1, A);
+
+			for (int i = x1; i <= x2; i++) {
+				int val = A(i - x1, j_min[i - x1]);
+				if (c[i] > val) c[i] = val;
+			}
+
+			return;
+		}
+
+		if ((long long)(x2 - x1) * (y2 - y1) < 1000) {
+			for (int x = x1; x <= x2; x++) {
+				int y_from = max(y_min[x], y1);
+				int y_to = min(y_max[x], y2);
+				for (int y = y_from; y <= y_to; y++) {
+					int val = a[y] + b[x - y];
+					if (c[x] > val) c[x] = val;
+				}
+			}
+			return;
+		}
+
+		if (x2 - x1 > y2 - y1) {
+			int xm = (x1 + x2) / 2;
+
+			int ny2 = min(y_max[xm], y2);
+			if (y1 <= ny2) rf(x1, xm, y1, ny2);
+
+			int ny1 = max(y_min[xm], y1);
+			if (ny1 <= y2) rf(xm + 1, x2, ny1, y2);
+		}
+		else {
+			int ym = (y1 + y2) / 2;
+
+			int nx2 = min(x_max[ym], x2);
+			if (x1 <= nx2) rf(x1, nx2, y1, ym);
+
+			int nx1 = max(x_min[ym], x1);
+			if (nx1 <= x2) rf(nx1, x2, ym + 1, y2);
+		}
+	};
+	rf(0, h - 1, 0, w - 1);
+
+	return c;
+}

--- a/convolution/min_plus_convolution_convex_arbitrary/grader/grader.cpp
+++ b/convolution/min_plus_convolution_convex_arbitrary/grader/grader.cpp
@@ -1,0 +1,41 @@
+#include <chrono>
+#include <iostream>
+#include <utility>
+
+#include "fastio.h"
+#include "solve.hpp"
+
+using namespace std::chrono;
+using namespace library_checker;
+
+int main() {
+    Scanner sc = Scanner(stdin);
+    Printer pr = Printer(stdout);
+
+    int n = 0, m = 0;
+    sc.read(n, m);
+
+    std::vector<int> a(n), b(m);
+    for (int i = 0; i < n; i++) {
+        sc.read(a[i]);
+    }
+    for (int i = 0; i < m; i++) {
+        sc.read(b[i]);
+    }
+
+    steady_clock::time_point begin = steady_clock::now();
+    auto ans = solve(std::move(a), std::move(b));
+    steady_clock::time_point end = steady_clock::now();
+
+    auto elapsed_time = duration_cast<milliseconds>(end - begin);
+    std::cerr << "solve() consumes: " << elapsed_time.count() << "ms"
+              << std::endl;
+
+    for (int i = 0; i <= (n - 1) + (m - 1); i++) {
+        if (i) pr.write(' ');
+        pr.write(ans[i]);
+    }
+    pr.writeln();
+
+    return 0;
+}

--- a/convolution/min_plus_convolution_convex_arbitrary/grader/solve.hpp
+++ b/convolution/min_plus_convolution_convex_arbitrary/grader/solve.hpp
@@ -1,0 +1,3 @@
+#include <vector>
+
+std::vector<int> solve(std::vector<int> a, std::vector<int> b);

--- a/convolution/min_plus_convolution_convex_arbitrary/info.toml
+++ b/convolution/min_plus_convolution_convex_arbitrary/info.toml
@@ -50,6 +50,10 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/727"
     name = "naive.cpp"
     allow_tle = true
 
+[[solutions]]
+    name = "ac_func.cpp"
+    function = true
+
 [params]
     N_MAX = 524288
     A_MIN = 0

--- a/convolution/min_plus_convolution_convex_arbitrary/sol/ac_func.cpp
+++ b/convolution/min_plus_convolution_convex_arbitrary/sol/ac_func.cpp
@@ -1,0 +1,46 @@
+#include <iostream>
+#include <cstdio>
+#include <vector>
+#include <cassert>
+
+using namespace std;
+
+template <typename T>
+using vc = vector<T>;
+
+// select(i,j,k) : (i,j) -> (i,k)
+template <typename F>
+vc<int> monotone_minima(int H, int W, F select) {
+  vc<int> min_col(H);
+  auto dfs = [&](auto& dfs, int x1, int x2, int y1, int y2) -> void {
+    if (x1 == x2) return;
+    int x = (x1 + x2) / 2;
+    int best_y = y1;
+    for (int y = y1 + 1; y < y2; ++y) {
+      if (select(x, best_y, y)) best_y = y;
+    }
+    min_col[x] = best_y;
+    dfs(dfs, x1, x, y1, best_y + 1);
+    dfs(dfs, x + 1, x2, best_y, y2);
+  };
+  dfs(dfs, 0, H, 0, W);
+  return min_col;
+}
+
+vc<int> solve(vc<int> B, vc<int> A) {
+  int N = A.size(), M = B.size();
+  // B is convex
+  for (int i = 0; i < M - 2; ++i) assert(B[i] + B[i + 2] >= 2 * B[i + 1]);
+  auto select = [&](int i, int j, int k) -> bool {
+    if (i < k) return false;
+    if (i - j >= M) return true;
+    return A[j] + B[i - j] >= A[k] + B[i - k];
+  };
+  vc<int> J = monotone_minima(N + M - 1, N, select);
+  vc<int> C(N + M - 1);
+  for (int i = 0; i < N + M - 1; ++i) {
+    int j = J[i];
+    C[i] = A[j] + B[i - j];
+  }
+  return C;
+}

--- a/convolution/min_plus_convolution_convex_convex/grader/grader.cpp
+++ b/convolution/min_plus_convolution_convex_convex/grader/grader.cpp
@@ -1,0 +1,41 @@
+#include <chrono>
+#include <iostream>
+#include <utility>
+
+#include "fastio.h"
+#include "solve.hpp"
+
+using namespace std::chrono;
+using namespace library_checker;
+
+int main() {
+    Scanner sc = Scanner(stdin);
+    Printer pr = Printer(stdout);
+
+    int n = 0, m = 0;
+    sc.read(n, m);
+
+    std::vector<int> a(n), b(m);
+    for (int i = 0; i < n; i++) {
+        sc.read(a[i]);
+    }
+    for (int i = 0; i < m; i++) {
+        sc.read(b[i]);
+    }
+
+    steady_clock::time_point begin = steady_clock::now();
+    auto ans = solve(std::move(a), std::move(b));
+    steady_clock::time_point end = steady_clock::now();
+
+    auto elapsed_time = duration_cast<milliseconds>(end - begin);
+    std::cerr << "solve() consumes: " << elapsed_time.count() << "ms"
+              << std::endl;
+
+    for (int i = 0; i <= (n - 1) + (m - 1); i++) {
+        if (i) pr.write(' ');
+        pr.write(ans[i]);
+    }
+    pr.writeln();
+
+    return 0;
+}

--- a/convolution/min_plus_convolution_convex_convex/grader/solve.hpp
+++ b/convolution/min_plus_convolution_convex_convex/grader/solve.hpp
@@ -1,0 +1,3 @@
+#include <vector>
+
+std::vector<int> solve(std::vector<int> a, std::vector<int> b);

--- a/convolution/min_plus_convolution_convex_convex/info.toml
+++ b/convolution/min_plus_convolution_convex_convex/info.toml
@@ -38,6 +38,10 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/727"
     name = "naive.cpp"
     allow_tle = true
 
+[[solutions]]
+    name = "ac_func.cpp"
+    function = true
+
 [params]
     N_MAX = 524288
     A_MIN = 0

--- a/convolution/min_plus_convolution_convex_convex/sol/ac_func.cpp
+++ b/convolution/min_plus_convolution_convex_convex/sol/ac_func.cpp
@@ -1,0 +1,46 @@
+#include <iostream>
+#include <cstdio>
+#include <vector>
+#include <cassert>
+
+using namespace std;
+
+template <typename T>
+using vc = vector<T>;
+
+// select(i,j,k) : (i,j) -> (i,k)
+template <typename F>
+vc<int> monotone_minima(int H, int W, F select) {
+  vc<int> min_col(H);
+  auto dfs = [&](auto& dfs, int x1, int x2, int y1, int y2) -> void {
+    if (x1 == x2) return;
+    int x = (x1 + x2) / 2;
+    int best_y = y1;
+    for (int y = y1 + 1; y < y2; ++y) {
+      if (select(x, best_y, y)) best_y = y;
+    }
+    min_col[x] = best_y;
+    dfs(dfs, x1, x, y1, best_y + 1);
+    dfs(dfs, x + 1, x2, best_y, y2);
+  };
+  dfs(dfs, 0, H, 0, W);
+  return min_col;
+}
+
+vc<int> solve(vc<int> B, vc<int> A) {
+  int N = A.size(), M = B.size();
+  // B is convex
+  for (int i = 0; i < M - 2; ++i) assert(B[i] + B[i + 2] >= 2 * B[i + 1]);
+  auto select = [&](int i, int j, int k) -> bool {
+    if (i < k) return false;
+    if (i - j >= M) return true;
+    return A[j] + B[i - j] >= A[k] + B[i - k];
+  };
+  vc<int> J = monotone_minima(N + M - 1, N, select);
+  vc<int> C(N + M - 1);
+  for (int i = 0; i < N + M - 1; ++i) {
+    int j = J[i];
+    C[i] = A[j] + B[i - j];
+  }
+  return C;
+}


### PR DESCRIPTION
* 入出力律速がちで、本体の実行時間が分かりにくい
* SMAWK と O((n+m) log (n+m)) monotone minima を混ぜた速度比較とかもっとあってもいいと思う
* grader の実装が自明
* 入出力形式を決めてしまうことによる懸念もほぼない

という理由で、下記 3 問の  C++(Function) 用 grader を追加( convolution_mod の grader をコピペ)します。

* [Min Plus Convolution (Convex and Arbitrary)](https://judge.yosupo.jp/problem/min_plus_convolution_convex_arbitrary)
* [Min Plus Convolution (Convex and Convex)](https://judge.yosupo.jp/problem/min_plus_convolution_convex_convex)
* [Min Plus Convolution (Concave and Arbitrary)](https://judge.yosupo.jp/problem/min_plus_convolution_concave_arbitrary)