### PR TITLE
Update magic constant for `unordered_map_killer`

### DIFF
--- a/data_structure/associative_array/gen/unordered_map_killer.cpp
+++ b/data_structure/associative_array/gen/unordered_map_killer.cpp
@@ -34,8 +34,8 @@ int main(int, char* argv[]) {
     long long seed = atoll(argv[1]);
     auto gen = Random(seed);
 
-    // magic for ideone, judge, clang++(OS X)
-    int MAGIC = vector<int>({256279, 218971, 205759})[seed % 3];
+    // magic for ideone, judge, clang++(OS X), onlinegdb
+    int MAGIC = vector<int>({256279, 218971, 205759, 172933})[seed % 4];
 
     int Q = Q_MAX;
     printf("%d\n", Q);

--- a/data_structure/associative_array/hash.json
+++ b/data_structure/associative_array/hash.json
@@ -34,5 +34,7 @@
   "unordered_map_killer_01.in": "96e853bb9efd434e3a11d115a12f5b29ae85fc15e8bf84477995fcc5643756e3",
   "unordered_map_killer_01.out": "8785fe632aaa363af4b99d5ce8ef3638c90fe86f36afba83dedf7c5b5903783b",
   "unordered_map_killer_02.in": "f7d1ae5706bf7db22825738815beb929178482fd50b66fa8bb05cad8da8cf9dd",
-  "unordered_map_killer_02.out": "4e1bf0c0e07f6edbb5822e7b0d19b36d89c45c5e1e8a604ef4bfbb7610a2c7ac"
+  "unordered_map_killer_02.out": "4e1bf0c0e07f6edbb5822e7b0d19b36d89c45c5e1e8a604ef4bfbb7610a2c7ac",
+  "unordered_map_killer_03.in": "faf8312be882a629a1e20949f53533d096ef8a3c5280d211268143306c0f72dc",
+  "unordered_map_killer_03.out": "9ead08f2e504331487339a4c0f6258395c1262ac72dc402f34b8acd01ef6057a"
 }

--- a/data_structure/associative_array/info.toml
+++ b/data_structure/associative_array/info.toml
@@ -16,7 +16,7 @@ forum = 'https://github.com/yosupo06/library-checker-problems/issues/376'
     number = 1
 [[tests]]
     name = "unordered_map_killer.cpp"
-    number = 3
+    number = 4
 [[tests]]
     name = "sparse_keys.cpp"
     number = 2


### PR DESCRIPTION
Previous magic constant generated from ideone is only for C++14 (and below?). I have updated it to a new constant which would work from C++17 to C++23. Checked the constant locally, through Library Checker's [hacks](https://judge.yosupo.jp/hack/621) and on [onlinegdb](https://www.onlinegdb.com/).

Resolves #1338.