### PR TITLE
Add tests to bipartitematching 

### DIFF
--- a/graph/bipartitematching/gen/augmented_cycle.cpp
+++ b/graph/bipartitematching/gen/augmented_cycle.cpp
@@ -1,0 +1,63 @@
+#include <algorithm>
+#include <cassert>
+#include <iostream>
+
+#include "../params.h"
+#include "random.h"
+
+int main(int, char* argv[]) {
+    std::ios::sync_with_stdio(false);
+    std::cin.tie(nullptr);
+
+    long long seed = atoll(argv[1]);
+    auto gen = Random(seed);
+
+    constexpr int L = L_MAX, R = R_MAX, M = M_MAX;
+    constexpr int N = std::min(L, R);
+
+    std::vector<std::pair<int, int>> edg;
+    if (seed == 0) {
+        const int n = std::min(N, M / 3);
+        for (int i = 0; i < n; i++) {
+            edg.push_back({i, i});
+            edg.push_back({i, (i + 1) % n});
+            edg.push_back({i, gen.uniform<int>(0, i)});
+        }
+    } else if (seed == 1) {
+        const int n = std::min(N, M / 3);
+        const int W = 250;
+        for (int i = 0; i < n; i++) {
+            edg.push_back({i, i});
+            edg.push_back({i, (i + 1) % n});
+            edg.push_back({i, gen.uniform<int>(std::max(0, i - 2 * W), std::max(0, i - W))});
+        }
+    } else if (seed == 2) {
+        const int n = std::min(N, M / 3);
+        const int W = 1000;
+        for (int i = 0; i < n; i++) {
+            edg.push_back({i, i});
+            edg.push_back({i, (i + 1) % n});
+            edg.push_back({i, gen.uniform<int>(std::max(0, i - 2 * W), i)});
+        }
+    } else {
+        assert(false);
+    }
+
+    std::sort(edg.begin(), edg.end());
+    edg.erase(std::unique(edg.begin(), edg.end()), edg.end());
+
+    std::vector<int> p1(L), p2(R);
+    std::iota(p1.begin(), p1.end(), 0);
+    std::iota(p2.begin(), p2.end(), 0);
+
+    gen.shuffle(p1.begin(), p1.end());
+    gen.shuffle(p2.begin(), p2.end());
+    gen.shuffle(edg.begin(), edg.end());
+
+    std::cout << N << " " << N << " " << edg.size() << "\n";
+    for (auto& [u, v] : edg) {
+        std::cout << p1[u] << " " << p2[v] << "\n";
+    }
+
+    return 0;
+}

--- a/graph/bipartitematching/hash.json
+++ b/graph/bipartitematching/hash.json
@@ -1,4 +1,10 @@
 {
+  "augmented_cycle_00.in": "8ead2630ed5641d57d4bc8a7160a7e2e52dd2d3417bc94bcec021a4ab77e5b56",
+  "augmented_cycle_00.out": "7f17b05c9b02f135e937df206a4737c53f527ed4972972760a8fbf627dac4f56",
+  "augmented_cycle_01.in": "baeb6b46827cfcc84f408349c09103935022be01959834cb1e51abaf1b8655d4",
+  "augmented_cycle_01.out": "c0734809c818df0a6f798933f783d349808c0e16773e12bd3496b2a0e315c10a",
+  "augmented_cycle_02.in": "7ebba8dbab8b549b51d7907fdd8f141e7088c54d6e7a0d86b9f8dc7c5a1b9d92",
+  "augmented_cycle_02.out": "84f1ddf1f20b8c836e17c65596b2b0ea68e4c881850d0ed5885a191dbb5b6ac5",
   "cycle_00.in": "257dbb1649ccc2cdc6c26ee4d0aa64cc389869e3be332149301c5252e24beb49",
   "cycle_00.out": "926e24287e47a0dbca8fc859568e13a17a7cdaa2c743ef43711fac0b8c17c37f",
   "cycle_01.in": "9e22c4911eb6bd53f9db7cb8b837b8cff9cb78972f638eb3ef30cbb794852455",

--- a/graph/bipartitematching/info.toml
+++ b/graph/bipartitematching/info.toml
@@ -41,6 +41,9 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/37"
 [[tests]]
     name = "unique_matching.cpp"
     number = 5
+[[tests]]
+    name = "augmented_cycle.cpp"
+    number = 3
 
 [params]
     L_MAX = 100_000


### PR DESCRIPTION
https://judge.yosupo.jp/hack/715  (95ms -> 169ms)
https://judge.yosupo.jp/hack/719  (154ms -> 288ms)
https://judge.yosupo.jp/hack/712  (78ms -> 705ms)

Differences from #1349:
- use a cycle instead of a path to counter the "remove leaf" heuristic
- generate additional random edges in a different way