### PR TITLE
CI エラー修正

### DIFF
--- a/convolution/mul_mod2n_convolution/info.toml
+++ b/convolution/mul_mod2n_convolution/info.toml
@@ -23,7 +23,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/728"
 
 [[solutions]]
     name = "naive.cpp"
-    expect = "TLE"
+    expect = "RE"
 
 [params]
     N_MAX = 20

--- a/geo/furthest_pair/info.toml
+++ b/geo/furthest_pair/info.toml
@@ -52,7 +52,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/837"
 
 [[solutions]]
     name = "uso_caliper.cpp"
-    wrong = true
+    expect = "WA"
 
 [[solutions]]
     name = "naive.cpp"

--- a/graph/bipartite_edge_coloring/sol/correct.cpp
+++ b/graph/bipartite_edge_coloring/sol/correct.cpp
@@ -303,6 +303,7 @@ std::vector<int> solve(int L,int R,int M,int a[],int b[]) {
 
 std::mt19937 mt;
 
+/*
 void gen() {
   int L=100000;
   int R=100000;
@@ -337,12 +338,15 @@ void verify() {
     printf("time %lf[ms]\n", time);
   }
 }
+*/
+
+const int MAX_M = 100000;
 
 void solve() {
   int L,R,M;
   scanf("%d%d%d",&L,&R,&M);
-  int a[M];
-  int b[M];
+  int a[MAX_M];
+  int b[MAX_M];
   for (int i=0;i<M;++i) {
     scanf("%d%d\n",&a[i],&b[i]);
   }

--- a/graph/bipartite_edge_coloring/sol/correct.cpp
+++ b/graph/bipartite_edge_coloring/sol/correct.cpp
@@ -304,6 +304,8 @@ std::vector<int> solve(int L,int R,int M,int a[],int b[]) {
 std::mt19937 mt;
 
 /*
+// causion : The function below uses variable-length
+//           arrays, which are compiler-dependent.
 void gen() {
   int L=100000;
   int R=100000;

--- a/graph/cycle_detection/info.toml
+++ b/graph/cycle_detection/info.toml
@@ -23,7 +23,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/534"
 
 [[solutions]]
 	name = 'source_zero.cpp'
-	expect = "TLE"
+	expect = "WA"
 
 [params]
 	N_MIN = 2

--- a/graph/enumerate_cliques/info.toml
+++ b/graph/enumerate_cliques/info.toml
@@ -32,7 +32,8 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/820"
 
 [[solutions]]
 	name = 'naive.cpp'
-	expect = "TLE"
+	expect = "WA"
+	allow_tle = true
 
 [params]
 	N_MIN = 1

--- a/graph/enumerate_triangles/info.toml
+++ b/graph/enumerate_triangles/info.toml
@@ -29,7 +29,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/442"
 
 [[solutions]]
 	name = 'naive.cpp'
-	expect = "WA"
+	allow_tle = true
 [[solutions]]
 	name = 'correct_slow.cpp'
 [[solutions]]

--- a/polynomial/composition_of_formal_power_series_large/info.toml
+++ b/polynomial/composition_of_formal_power_series_large/info.toml
@@ -32,7 +32,8 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/1112"
     allow_re = true
 [[solutions]]
     name = "wa.cpp"
-    expect = "WA"
+    expect = "RE"
+    allow_tle = true
 
 [params]
     N_MAX = 131_072

--- a/polynomial/pow_of_formal_power_series/info.toml
+++ b/polynomial/pow_of_formal_power_series/info.toml
@@ -42,6 +42,7 @@ forum = "https://github.com/yosupo06/library-checker-problems/issues/386"
 [[solutions]]
     name = "wa_overflow.cpp"
     expect = "WA"
+    allow_tle = true
     
 [params]
     N_MAX = 500000

--- a/string/wildcard_pattern_matching/sol/bruteforce.cpp
+++ b/string/wildcard_pattern_matching/sol/bruteforce.cpp
@@ -1,7 +1,7 @@
 #include <string>
 #include <iostream>
 
-static char buf[1 << 19];
+static char buf[(1 << 19) + 1];
 std::string scan()
 {
     scanf("%s", buf);

--- a/string/wildcard_pattern_matching/sol/correct.cpp
+++ b/string/wildcard_pattern_matching/sol/correct.cpp
@@ -1065,7 +1065,7 @@ namespace atcoder
 
 using ll = long long;
 
-static char buf[1 << 19];
+static char buf[(1 << 19) + 1];
 std::string scan()
 {
     scanf("%s", buf);

--- a/string/wildcard_pattern_matching/sol/mod998244353.cpp
+++ b/string/wildcard_pattern_matching/sol/mod998244353.cpp
@@ -1065,7 +1065,7 @@ namespace atcoder
 
 using ll = long long;
 
-static char buf[1 << 19];
+static char buf[(1 << 19) + 1];
 std::string scan()
 {
     scanf("%s", buf);


### PR DESCRIPTION
#1350 の CI で出たエラーを修正します。

* `wildcard_pattern_matching/sol/bruteforce` : RE が再現しなかったので、変更内容に**自信なし**。文字列を `scanf` で入力するときのバッファに `\0` が入る分のスペースがなかったので、それを確保する。

.

* `bipartite_edge_coloring/sol/correct` : 変数長配列を置換、使用されていない関数をコメントアウト
* `composition_of_formal_power_series_large/sol/wa` : そもそも RE 想定。元のアルゴリズムが N=8000 想定なので TLE もする。
* `cycle_detection/sol/source_zero` : 始点 0 のみ考慮する WA 想定である。
* `enumerate_cliques/sol/naive` : `if(n > 30) return 0;` を入れている WA 想定。 N=30 なら TLE もするかも
* `enumerate_triangles/sol/naive` : N^3 解。 TLE 想定。
* `furthest_pair/sol/uso_caliper` : WA 想定。
* `mul_mod2n_convolution/sol/naive` : `assert(n <= 14);` 。 RE 想定で、おそらく TLE はしない。
* `pow_of_formal_power_series_sparse/sol/wa_overflow` : シフト幅の計算がオーバーフローする、 WA 想定。そもそも想定解が結構遅いので、 TLE 許容は残すべきっぽい？