### PR TITLE
[convolution_F_2_64] Fix missing forum link

### DIFF
--- a/convolution/convolution_F_2_64/info.toml
+++ b/convolution/convolution_F_2_64/info.toml
@@ -1,5 +1,6 @@
 title = 'Convolution ($\mathbb{F}_{2^{64}}$)'
 timelimit = 10.0
+forum = "https://github.com/yosupo06/library-checker-problems/issues/1367"
 
 [[tests]]
     name = "example.in"


### PR DESCRIPTION
Convolution ($\mathbb{F}_{2^{64}}$) https://judge.yosupo.jp/problem/convolution_F_2_64 に Forum をリンクします。