### PR TITLE
Determinant of Matrixの日本語問題文のフォーマットを修正

### DIFF
--- a/linear_algebra/matrix_det/task.md
+++ b/linear_algebra/matrix_det/task.md
@@ -3,7 +3,7 @@
 @{lang.en}
 Given $N \times N$ matrix $M = \lbrace a_{ij} \rbrace$. Print $\mathrm{det}(M) \bmod 998244353$.
 @{lang.ja}
-$N \times N$ 正方行列 $a_{ij}$ が与えられます。行列式をmod 998244353で求めてください。
+$N \times N$ 正方行列 $a_{ij}$ が与えられます。行列式を $\mod 998244353$ で求めてください。
 @{lang.end}
 
 ## @{keyword.constraints}


### PR DESCRIPTION
他の問題と揃っていなかったので、\$\$ を付けました。
元問題文
<img width="1290" height="197" alt="image" src="https://github.com/user-attachments/assets/5d062512-3328-4386-8d16-fa25a9cc466f" />
