### PR TITLE
Fix flaky compiling error

### DIFF
--- a/enumerative_combinatorics/sharp_p_subset_sum/sol/correct.cpp
+++ b/enumerative_combinatorics/sharp_p_subset_sum/sol/correct.cpp
@@ -200,7 +200,8 @@ int main(){
    for(int k=1;k<=t;k++)for(int j=1;j<=t/k;j++){
       Mint add=fact.inv(j)*cnt[k];
       if(j&1)f[k*j]+=add; else f[k*j]-=add;
-   } f=f.exp();
+   }
+   f=f.exp();
    for(int i=1;i<=t;i++) {
       printf("%d",f[i].val);
       if(i<t)printf(" ");


### PR DESCRIPTION
Recently, `All generate test` is flaky.

```text
06:59:03 [DEBUG] compile: ['clang++', '-O2', '-std=c++17', '-Wall', '-Wextra', '-Werror', '-Wno-unused-result', '-Wl,-stack_size,0x10000000', '-I', '/Users/runner/work/library-checker-problems/library-checker-problems/common', '-o', 'enumerative_combinatorics/sharp_p_subset_sum/sol/correct', 'enumerative_combinatorics/sharp_p_subset_sum/sol/correct.cpp']
enumerative_combinatorics/sharp_p_subset_sum/sol/correct.cpp:203:6: error: misleading indentation; statement is not part of the previous 'for' [-Werror,-Wmisleading-indentation]
  203 |    } f=f.exp();
      |      ^
enumerative_combinatorics/sharp_p_subset_sum/sol/correct.cpp:200:4: note: previous statement is here
  200 |    for(int k=1;k<=t;k++)for(int j=1;j<=t/k;j++){
      |    ^
1 error generated.
```

